### PR TITLE
[Feat] 일관된 로깅을 위한 로그백 구성

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="Console">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="RollingFile">
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </encoder>
+    <file>${LOGS}/spring-boot-logger.log</file>
+
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>ERROR</level>
+    </filter>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxHistory>20</maxHistory>
+      <timeBasedFileNamingAndTriggeringPolicy
+        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>10MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+    </rollingPolicy>
+  </appender>
+
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+  <property name="LOGS" value="./logs"/>
+
+  <root level="ERROR">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="RollingFile"/>
+  </root>
+</configuration>


### PR DESCRIPTION
# ⭐️ [Feat] 일관된 로깅을 위한 로그백 구성

- 이 구성을 통해 에러 로그만 모아서 볼 수 있으며, 애플리케이션의 디버깅 및 모니터링을 용이하게 합니다.

## 🛠️ 변경 사항

**배경 및 목적 :**
 - Spring Boot 애플리케이션을 위한 로그백 구성 파일을 도입한다.
- 일관된 로깅은 애플리케이션의 디버깅 및 모니터링을 용이하게 한다.

**변경 사항:**
 - 일관된 형식으로 콘솔에 로그를 기록하기 위해 ConsoleAppender를 추가했습니다.
 - 로그를 파일에 저장하고 로그 회전을 관리하기 위해 RollingFileAppender를 추가했습니다.
 - 로그가 10MB를 초과하거나 하루가 지날 때마다 로그를 회전시키는 TimeBasedRollingPolicy를 구성했습니다.
 - 로그를 ERROR 레벨 이상으로 제한하기 위해 ThresholdFilter를 적용했습니다.

## ❗️ 관련 이슈

- #23 

## 🛠️ 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-04-30)
- 작업 종료일: (2024-04-30)

## 📌 유의사항

- 로그는 ./logs 디렉토리에 저장되며, 루트 디렉토리 아래 'logs' 폴더에서 확인할 수 있습니다.
- logback-spring.xml 파일의 level 설정을 변경하면서 자유롭게 필터링 레벨을 조절하실 수 있습니다.
- 로컬에서 생선된 로그 파일이 같이 push 되지 않도록 주의해주세요!(후에 .gitignore 에 추가 예정)
- 더 자세한 설명은 #23 참고해주세요!😊

