### PR TITLE
[Feat] 도메인을 나누고 엔터티 클래스를 추가한다.

### DIFF
--- a/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
+++ b/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
@@ -1,0 +1,60 @@
+package com.final_10aeat.domain.admin.entity;
+
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "admin")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends SoftDeletableBaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column
+    private String password;
+
+    @Column
+    private String name;
+
+    @Column(name = "phonenumber")
+    private String phoneNumber;
+
+    @Column(name = "lunch_start")
+    private LocalDateTime lunchBreakStart;
+
+    @Column(name = "lunch_end")
+    private LocalDateTime lunchBreakEnd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role = MemberRole.ADMIN;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "office_id")
+    private Office office;
+}

--- a/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
+++ b/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
@@ -50,6 +50,11 @@ public class Admin extends SoftDeletableBaseTimeEntity {
     @Column(name = "lunch_end")
     private LocalDateTime lunchBreakEnd;
 
+    @Column(name = "admin_office")
+    private String adminOffice;
+
+    private String affiliation;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MemberRole role = MemberRole.ADMIN;

--- a/src/main/java/com/final_10aeat/domain/admin/entity/Office.java
+++ b/src/main/java/com/final_10aeat/domain/admin/entity/Office.java
@@ -1,0 +1,38 @@
+package com.final_10aeat.domain.admin.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "office")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Office {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "office_name")
+    private String officeName;
+
+    @Column
+    private String adress;
+
+    @Column(name = "map_x")
+    private String mapX;
+
+    @Column(name = "map_y")
+    private String mapY;
+}

--- a/src/main/java/com/final_10aeat/domain/articleInteraction/entity/ArticleCheck.java
+++ b/src/main/java/com/final_10aeat/domain/articleInteraction/entity/ArticleCheck.java
@@ -1,0 +1,39 @@
+package com.final_10aeat.domain.articleInteraction.entity;
+
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_article_check")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleCheck extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repair_article_id")
+    private RepairArticle repairArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/final_10aeat/domain/articleInteraction/entity/ArticleSave.java
+++ b/src/main/java/com/final_10aeat/domain/articleInteraction/entity/ArticleSave.java
@@ -1,0 +1,39 @@
+package com.final_10aeat.domain.articleInteraction.entity;
+
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_article_save")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleSave extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repair_article_id")
+    private RepairArticle repairArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssue.java
+++ b/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssue.java
@@ -1,0 +1,45 @@
+package com.final_10aeat.domain.articleIssue.entity;
+
+import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "article_issue")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleIssue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manage_article_id", referencedColumnName = "id")
+    private ManageArticle manageArticle;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repair_article_id", referencedColumnName = "id")
+    private RepairArticle repairArticle;
+}

--- a/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssueCheck.java
+++ b/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssueCheck.java
@@ -1,0 +1,41 @@
+package com.final_10aeat.domain.articleIssue.entity;
+
+import com.final_10aeat.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "article_issue_ischeck")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleIssueCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ischeck")
+    private boolean isCheck;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_issue_id")
+    private ArticleIssue articleIssue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
+++ b/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
@@ -1,0 +1,46 @@
+package com.final_10aeat.domain.comment.entity;
+
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_comment")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends SoftDeletableBaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", name = "content")
+    private String content;
+
+    @Column(name = "parent_comment_id")
+    private Long parentComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repair_article_id")
+    private RepairArticle repairArticle;
+}

--- a/src/main/java/com/final_10aeat/domain/comment/entity/CommentLike.java
+++ b/src/main/java/com/final_10aeat/domain/comment/entity/CommentLike.java
@@ -1,0 +1,38 @@
+package com.final_10aeat.domain.comment.entity;
+
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "comment_like")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
@@ -1,0 +1,63 @@
+package com.final_10aeat.domain.manageArticle.entity;
+
+import com.final_10aeat.domain.repairArticle.entity.Progress;
+import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "manage_article")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManageArticle extends SoftDeletableBaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Progress progress = Progress.INPROGRESS;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ManagePeriod period;
+
+    @Column(name = "period_count")
+    private int periodCount;
+
+    @Column
+    private String title;
+
+    @Column(name = "legal_basis")
+    private String legalBasis;
+
+    @Column
+    private String target;
+
+    @Column
+    private String manager;
+
+    @Column(columnDefinition = "TEXT")
+    private String note;
+
+    @OneToMany(mappedBy = "manageArticle", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ManageSchedule> schedules;
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManagePeriod.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManagePeriod.java
@@ -1,5 +1,5 @@
 package com.final_10aeat.domain.manageArticle.entity;
 
 public enum ManagePeriod {
-    YEAR, MONTH, WEEK
+    YEAR, MONTH, WEEK, HALF
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManagePeriod.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManagePeriod.java
@@ -1,0 +1,5 @@
+package com.final_10aeat.domain.manageArticle.entity;
+
+public enum ManagePeriod {
+    YEAR, MONTH, WEEK
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
@@ -1,0 +1,41 @@
+package com.final_10aeat.domain.manageArticle.entity;
+
+import com.final_10aeat.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "manage_schedule")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManageSchedule extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ischeck")
+    private boolean isCheck;
+
+    @Column
+    private LocalDateTime schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manage_article_id")
+    private ManageArticle manageArticle;
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
@@ -29,8 +29,8 @@ public class ManageSchedule {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "ischeck")
-    private boolean isCheck;
+    @Column(name = "iscomplete")
+    private boolean isComplete;
 
     @Column
     private LocalDateTime schedule;

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "manage_schedule")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ManageSchedule extends BaseTimeEntity {
+public class ManageSchedule {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/final_10aeat/domain/member/entity/BuildingInfo.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/BuildingInfo.java
@@ -1,0 +1,41 @@
+package com.final_10aeat.domain.member.entity;
+
+import com.final_10aeat.domain.admin.entity.Office;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "member_building_info")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuildingInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private int dong;
+
+    @Column
+    private int ho;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "office_id")
+    private Office office;
+
+}

--- a/src/main/java/com/final_10aeat/domain/member/entity/BuildingInfo.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/BuildingInfo.java
@@ -29,10 +29,10 @@ public class BuildingInfo {
     private Long id;
 
     @Column
-    private int dong;
+    private String dong;
 
     @Column
-    private int ho;
+    private String ho;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "office_id")

--- a/src/main/java/com/final_10aeat/domain/member/entity/Member.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/Member.java
@@ -1,15 +1,15 @@
 package com.final_10aeat.domain.member.entity;
 
+import com.final_10aeat.domain.admin.entity.Office;
 import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
 import jakarta.persistence.*;
+import java.util.Set;
 import lombok.*;
 
 @Entity
 @Getter
 @Builder
-@Table(name = "member", indexes = @Index(
-        name = "idx_email_deletedAt", columnList = "email, deletedAt", unique = true
-))
+@Table(name = "member")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends SoftDeletableBaseTimeEntity {
@@ -23,4 +23,27 @@ public class Member extends SoftDeletableBaseTimeEntity {
 
     @Column
     private String password;
+
+    @Column
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    @ManyToMany
+    @JoinTable(
+        name = "member_building",
+        joinColumns = @JoinColumn(name = "member_id"),
+        inverseJoinColumns = @JoinColumn(name = "building_info_id")
+    )
+    private Set<BuildingInfo> buildingInfos;
+
+    @ManyToMany
+    @JoinTable(
+        name = "member_office",
+        joinColumns = @JoinColumn(name = "member_id"),
+        inverseJoinColumns = @JoinColumn(name = "office_id")
+    )
+    private Set<Office> offices;
 }

--- a/src/main/java/com/final_10aeat/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/MemberRole.java
@@ -1,0 +1,5 @@
+package com.final_10aeat.domain.member.entity;
+
+public enum MemberRole {
+    ADMIN, OWNER, TENANT
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/ArticleCategory.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/ArticleCategory.java
@@ -1,0 +1,5 @@
+package com.final_10aeat.domain.repairArticle.entity;
+
+public enum ArticleCategory {
+    INSTALL, REPAIR, REPLACE
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/CustomProgress.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/CustomProgress.java
@@ -1,0 +1,49 @@
+package com.final_10aeat.domain.repairArticle.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_custom_progress")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column
+    private String content;
+
+    @Column(name = "inprogress")
+    private boolean inProgress;
+
+    @Column(name = "schedule_start")
+    private LocalDateTime startSchedule;
+
+    @Column(name = "schedule_end")
+    private LocalDateTime endSchedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repair_article_id")
+    private RepairArticle repairArticle;
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/Progress.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/Progress.java
@@ -1,0 +1,5 @@
+package com.final_10aeat.domain.repairArticle.entity;
+
+public enum Progress {
+    COMPLETE, INPROGRESS, PENDDING
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
@@ -1,0 +1,70 @@
+package com.final_10aeat.domain.repairArticle.entity;
+
+import com.final_10aeat.domain.admin.entity.Admin;
+import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_article")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RepairArticle extends SoftDeletableBaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Progress progress = Progress.INPROGRESS;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ArticleCategory category;
+
+    @Column
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "construction_start")
+    private LocalDateTime startConstruction;
+
+    @Column(name = "construction_end")
+    private LocalDateTime endConstruction;
+
+    @Column(name = "repair_company")
+    private String company;
+
+    @Column(name = "repair_company_website", columnDefinition = "TEXT")
+    private String companyWebsite;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private Admin admin;
+
+    @OneToMany(mappedBy = "repairArticle", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Set<RepairArticleImage> images;
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticleImage.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticleImage.java
@@ -1,0 +1,36 @@
+package com.final_10aeat.domain.repairArticle.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "repair_image")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RepairArticleImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", name = "url")
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private RepairArticle repairArticle;
+}


### PR DESCRIPTION
# ⭐️ [Feat] 각 도메인의 엔터티 클래스를 추가한다.

- 데이터베이스 설계를 바탕으로 도메인을 나누고 엔터티 클래스를 추가하였습니다.

## 🛠️ 변경 사항

- 설계된 데이터베이스를 바탕으로 도메인을 나누었습니다.
- 엔터티 클래스를 모두 추가하였습니다.

![10aeat_erd](https://github.com/10aeat/10aeat_Backend/assets/105612931/e6286284-ed0a-4a7f-94af-7e2b41a1c9d5)



## ❗️ 관련 이슈

- #48 

## ❗️ 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-11)
- 작업 종료일: (2024-05-12)

## ❗️ 유의사항

- 변수명, 컬럼명에 오탈자가 없는지 잘 확인해주세요
- 연관관계가 잘 설정되어 있는지 확인해주세요
- 다대다 관계는 모두 중간 테이블을 만들었습니다.

## 📃 참고문헌

- https://docs.google.com/spreadsheets/d/1VVYvojPr0ur8nxwu3LKDxLDpJvo_1nbzCHjNMPq0W74/edit#gid=0
