### PR TITLE
[Feature] 이메일 인증코드 전송, 검증 기능을 구현한다.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:17-jdk-slim AS build
 WORKDIR /app
 COPY . .
-#RUN ./gradlew test
+RUN ./gradlew test
 RUN ./gradlew bootJar
 #RUN ./gradlew build --no-daemon -x test
 # 실행 단계

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -40,6 +38,12 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'io.github.cdimascio:java-dotenv:+'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok:1.18.28'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -34,18 +34,21 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.google.code.gson:gson:2.8.9'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'io.github.cdimascio:java-dotenv:+'
 
-    //jwt
+    // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    //redis
+    // database
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/email/email-api.adoc
+++ b/src/docs/asciidoc/email/email-api.adoc
@@ -1,0 +1,41 @@
+= Email REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+
+[[Email-Send-Verification]]
+== 이메일 인증 코드 전송
+
+이메일로 인증 코드를 전송하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/email-send-verification/http-request.adoc[]
+include::{snippets}/email-send-verification/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/email-send-verification/http-response.adoc[]
+include::{snippets}/email-send-verification/response-fields.adoc[]
+
+[[Email-Verify]]
+== 이메일 인증 코드 검증
+
+전송 인증 코드, 입력 인증 코드가 일치하는지 비교하는 API 입니다.
+
+* 전송 받은 인증 코드의 유효시간은 24시간 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/email-verify-code/http-request.adoc[]
+include::{snippets}/email-verify-code/request-fields.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/email-verify-code/http-response.adoc[]
+include::{snippets}/email-verify-code/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,41 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= 10aeat API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+== API
+
+=== link:email/email-api.html[이메일 API, window=blank]
+
+== API Common Response
+
+[[overview-http-status-code]]
+=== 1. HTTP Status Code
+
+|===
+| Status code | Useage
+| `200 OK` | 요청을 성공적으로 수행
+| `201 Created` | 생성 요청 (ex: 게시글 생성)을 성공적으로 수행
+| `400 Bad Request` | API 에 기술되어 있는 요구사항에 부적합 시 발생
+| `401 Unauthorized` | 해당 API에 대한 인증 정보가 없는 경우 발생
+| `403 Forbiddon` | 해당 API에 대한 권한이 없는 경우 발생
+| `404 NotFound` | 지원하지 않는 API 경로로 요청 시 발생
+| `500 Internal Server Error` | 내부 서버 에러
+|===
+
+[[overview-common-response]]
+=== 2. API Common Response
+
+* 10aeat API 에서 공통적으로 제공하는 Response 요소들입니다.
+* 통상적인 상황이나 에러 발생시 모두 제공되는 포맷입니다.
+* null이 포함되어 있는 필드는 출력되지 않습니다.
+
+include::{snippets}/common/response-body.adoc[]
+include::{snippets}/common/response-fields.adoc[]

--- a/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.member.controller;
 
 import com.final_10aeat.domain.member.dto.request.EmailRequestDto;
 import com.final_10aeat.domain.member.dto.request.EmailVerificationRequestDto;
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
 import com.final_10aeat.domain.member.service.EmailUseCase;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.validation.Valid;
@@ -28,9 +29,9 @@ public class EmailController {
     }
 
     @PostMapping("/verification")
-    public ResponseEntity<ResponseDTO<?>> verifyEmail(
+    public ResponseEntity<ResponseDTO<EmailVerificationResponseDto>> verifyEmail(
         @RequestBody @Valid EmailVerificationRequestDto verificationRequest) {
-        ResponseDTO<?> response = emailUseCase.verifyEmailCode(
+        ResponseDTO<EmailVerificationResponseDto> response = emailUseCase.verifyEmailCode(
             verificationRequest.email(), verificationRequest.code());
         return ResponseEntity.status(response.getCode()).body(response);
     }

--- a/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
@@ -31,8 +31,8 @@ public class EmailController {
     @PostMapping("/verification")
     public ResponseEntity<ResponseDTO<EmailVerificationResponseDto>> verifyEmail(
         @RequestBody @Valid EmailVerificationRequestDto verificationRequest) {
-        ResponseDTO<EmailVerificationResponseDto> response = emailUseCase.verifyEmailCode(
+        EmailVerificationResponseDto responseDto = emailUseCase.verifyEmailCode(
             verificationRequest.email(), verificationRequest.code());
-        return ResponseEntity.status(response.getCode()).body(response);
+        return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/EmailController.java
@@ -1,0 +1,37 @@
+package com.final_10aeat.domain.member.controller;
+
+import com.final_10aeat.domain.member.dto.request.EmailRequestDto;
+import com.final_10aeat.domain.member.dto.request.EmailVerificationRequestDto;
+import com.final_10aeat.domain.member.service.EmailUseCase;
+import com.final_10aeat.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/email")
+public class EmailController {
+
+    private final EmailUseCase emailUseCase;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Void>> mailConfirm(
+        @RequestBody @Valid EmailRequestDto emailRequest) throws Exception {
+        emailUseCase.sendVerificationEmail(emailRequest.email(), emailRequest.role(),
+            emailRequest.dong(), emailRequest.ho());
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    @PostMapping("/verification")
+    public ResponseEntity<ResponseDTO<?>> verifyEmail(
+        @RequestBody @Valid EmailVerificationRequestDto verificationRequest) {
+        ResponseDTO<?> response = emailUseCase.verifyEmailCode(
+            verificationRequest.email(), verificationRequest.code());
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/EmailRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/EmailRequestDto.java
@@ -1,0 +1,19 @@
+package com.final_10aeat.domain.member.dto.request;
+
+import com.final_10aeat.domain.member.entity.MemberRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EmailRequestDto(
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    String email,
+    @NotNull(message = "가입자가 소유자인지 입주자인지 선택해주세요.")
+    MemberRole role,
+    String dong,
+    @NotBlank(message = "호는 필수 항목입니다.")
+    String ho
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/EmailVerificationRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/EmailVerificationRequestDto.java
@@ -1,0 +1,15 @@
+package com.final_10aeat.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationRequestDto(
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    String email,
+
+    @NotBlank(message = "인증 코드는 필수 항목입니다.")
+    String code
+
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/member/dto/response/EmailVerificationResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/response/EmailVerificationResponseDto.java
@@ -1,0 +1,18 @@
+package com.final_10aeat.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailVerificationResponseDto {
+
+    private String email;
+    private String role;
+    private String dong;
+    private String ho;
+}

--- a/src/main/java/com/final_10aeat/domain/member/exception/EmailSendingException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/EmailSendingException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class EmailSendingException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_SENDING_FAILURE;
+
+    public EmailSendingException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/exception/EmailTemplateLoadException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/EmailTemplateLoadException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class EmailTemplateLoadException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_TEMPLATE_LOAD_FAILURE;
+
+    public EmailTemplateLoadException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/exception/InvalidVerificationCodeException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/InvalidVerificationCodeException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class InvalidVerificationCodeException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.INVALID_VERIFICATION_CODE;
+
+    public InvalidVerificationCodeException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/VerificationCodeExpiredException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class VerificationCodeExpiredException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED;
+
+    public VerificationCodeExpiredException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/service/DevelopEmailService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/DevelopEmailService.java
@@ -1,0 +1,128 @@
+package com.final_10aeat.domain.member.service;
+
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.exception.EmailSendingException;
+import com.final_10aeat.domain.member.exception.EmailTemplateLoadException;
+import com.final_10aeat.domain.member.exception.VerificationCodeExpiredException;
+import com.final_10aeat.global.util.ResponseDTO;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("develop")
+@RequiredArgsConstructor
+@Transactional
+public class DevelopEmailService implements EmailUseCase {
+
+    private final JavaMailSender javaMailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Gson gson = new Gson();
+    private static final String TEST_ID_EMAIL = "fasttime123@naver.com";
+
+    @Override
+    public String sendVerificationEmail(String to, MemberRole role, String dong, String ho)
+        throws MessagingException, UnsupportedEncodingException {
+        String authCode = generateAuthCode();
+        MimeMessage message = createMessage(to, authCode);
+        try {
+            javaMailSender.send(message);
+            JsonObject userInfo = new JsonObject();
+            userInfo.addProperty("email", to);
+            userInfo.addProperty("role", role.name());
+            userInfo.addProperty("dong", dong);
+            userInfo.addProperty("ho", ho);
+            saveVerificationCode(to, authCode, userInfo.toString(), 1440);
+            return authCode;
+        } catch (MailException ex) {
+            throw new EmailSendingException();
+        }
+    }
+
+    private void saveVerificationCode(String email, String code, String userInfo, long timeout) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        ops.set(email + ":code", code, timeout, TimeUnit.MINUTES);
+        ops.set(email + ":info", userInfo, timeout, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public ResponseDTO<EmailVerificationResponseDto> verifyEmailCode(String email, String code) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        String storedCode = ops.get(email + ":code");
+        String userInfoJson = ops.get(email + ":info");
+
+        if (storedCode == null || userInfoJson == null) {
+            throw new VerificationCodeExpiredException();
+        }
+
+        if (!code.equals(storedCode)) {
+            return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST,
+                "인증번호가 일치하지 않습니다.");
+        }
+
+        EmailVerificationResponseDto userInfo = gson.fromJson(userInfoJson,
+            EmailVerificationResponseDto.class);
+        return ResponseDTO.okWithData(userInfo);
+    }
+
+    private String generateAuthCode() {
+        Random random = new Random();
+        return random.ints(8, 0, 36)
+            .mapToObj(i -> i < 10 ? String.valueOf(i) : String.valueOf((char) (i - 10 + 'a')))
+            .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
+            .toString();
+    }
+
+    private MimeMessage createMessage(String to, String authCode)
+        throws MessagingException, UnsupportedEncodingException {
+        String setFrom = TEST_ID_EMAIL;
+        String title = "회원가입 인증 번호";
+
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true,
+            StandardCharsets.UTF_8.name());
+
+        String emailTemplate = loadEmailTemplate("email_template.html");
+
+        emailTemplate = emailTemplate.replace("{{authCode}}", authCode);
+
+        helper.setSubject(title);
+        helper.setFrom(new InternetAddress(setFrom, "10aeat", StandardCharsets.UTF_8.name()));
+        helper.setTo(to);
+        helper.setText(emailTemplate, true);
+
+        return message;
+    }
+
+    private String loadEmailTemplate(String templateName) {
+        try {
+            Resource resource = new ClassPathResource("templates/" + templateName);
+            InputStream inputStream = resource.getInputStream();
+            byte[] templateBytes = inputStream.readAllBytes();
+            return new String(templateBytes, StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            throw new EmailTemplateLoadException();
+        }
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/service/DevelopEmailService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/DevelopEmailService.java
@@ -4,6 +4,7 @@ import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.domain.member.exception.EmailSendingException;
 import com.final_10aeat.domain.member.exception.EmailTemplateLoadException;
+import com.final_10aeat.domain.member.exception.InvalidVerificationCodeException;
 import com.final_10aeat.domain.member.exception.VerificationCodeExpiredException;
 import com.final_10aeat.global.util.ResponseDTO;
 import com.google.gson.Gson;
@@ -67,7 +68,7 @@ public class DevelopEmailService implements EmailUseCase {
     }
 
     @Override
-    public ResponseDTO<EmailVerificationResponseDto> verifyEmailCode(String email, String code) {
+    public EmailVerificationResponseDto verifyEmailCode(String email, String code) {
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
         String storedCode = ops.get(email + ":code");
         String userInfoJson = ops.get(email + ":info");
@@ -75,15 +76,10 @@ public class DevelopEmailService implements EmailUseCase {
         if (storedCode == null || userInfoJson == null) {
             throw new VerificationCodeExpiredException();
         }
-
         if (!code.equals(storedCode)) {
-            return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST,
-                "인증번호가 일치하지 않습니다.");
+            throw new InvalidVerificationCodeException();
         }
-
-        EmailVerificationResponseDto userInfo = gson.fromJson(userInfoJson,
-            EmailVerificationResponseDto.class);
-        return ResponseDTO.okWithData(userInfo);
+        return gson.fromJson(userInfoJson, EmailVerificationResponseDto.class);
     }
 
     private String generateAuthCode() {

--- a/src/main/java/com/final_10aeat/domain/member/service/EmailUseCase.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/EmailUseCase.java
@@ -2,7 +2,6 @@ package com.final_10aeat.domain.member.service;
 
 import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
-import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.mail.MessagingException;
 import java.io.UnsupportedEncodingException;
 
@@ -11,5 +10,5 @@ public interface EmailUseCase {
     String sendVerificationEmail(String to, MemberRole role, String dong, String ho)
         throws MessagingException, UnsupportedEncodingException;
 
-    ResponseDTO<EmailVerificationResponseDto> verifyEmailCode(String email, String code);
+    EmailVerificationResponseDto verifyEmailCode(String email, String code);
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/EmailUseCase.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/EmailUseCase.java
@@ -1,0 +1,15 @@
+package com.final_10aeat.domain.member.service;
+
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.global.util.ResponseDTO;
+import jakarta.mail.MessagingException;
+import java.io.UnsupportedEncodingException;
+
+public interface EmailUseCase {
+
+    String sendVerificationEmail(String to, MemberRole role, String dong, String ho)
+        throws MessagingException, UnsupportedEncodingException;
+
+    ResponseDTO<EmailVerificationResponseDto> verifyEmailCode(String email, String code);
+}

--- a/src/main/java/com/final_10aeat/domain/member/service/LocalEmailService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/LocalEmailService.java
@@ -1,0 +1,77 @@
+package com.final_10aeat.domain.member.service;
+
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.exception.VerificationCodeExpiredException;
+import com.final_10aeat.global.util.ResponseDTO;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Profile({"local", "test"})
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class LocalEmailService implements EmailUseCase {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Gson gson = new Gson();
+
+    @Override
+    public String sendVerificationEmail(String to, MemberRole role, String dong, String ho) {
+        String authCode = generateAuthCode();
+        log.info("이메일 인증번호 발송");
+        log.info("email : {}", to);
+        log.info("code : {}", authCode);
+        JsonObject userInfo = new JsonObject();
+        userInfo.addProperty("email", to);
+        userInfo.addProperty("role", role.name());
+        userInfo.addProperty("dong", dong);
+        userInfo.addProperty("ho", ho);
+        saveVerificationCode(to, authCode, userInfo.toString(), 1440);
+        return authCode;
+    }
+
+    private void saveVerificationCode(String email, String code, String userInfo, long timeout) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        ops.set(email + ":code", code, timeout, TimeUnit.MINUTES);
+        ops.set(email + ":info", userInfo, timeout, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public ResponseDTO<EmailVerificationResponseDto> verifyEmailCode(String email, String code) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        String storedCode = ops.get(email + ":code");
+        String userInfoJson = ops.get(email + ":info");
+
+        if (storedCode == null || userInfoJson == null) {
+            throw new VerificationCodeExpiredException();
+        }
+
+        if (!code.equals(storedCode)) {
+            return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다.");
+        }
+
+        EmailVerificationResponseDto userInfo = gson.fromJson(userInfoJson,
+            EmailVerificationResponseDto.class);
+        return ResponseDTO.okWithData(userInfo);
+    }
+
+    private String generateAuthCode() {
+        Random random = new Random();
+        return random.ints(8, 0, 36)
+            .mapToObj(i -> i < 10 ? String.valueOf(i) : String.valueOf((char) (i - 10 + 'a')))
+            .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
+            .toString();
+    }
+}

--- a/src/main/java/com/final_10aeat/global/config/EmailConfig.java
+++ b/src/main/java/com/final_10aeat/global/config/EmailConfig.java
@@ -1,0 +1,48 @@
+package com.final_10aeat.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Profile("develop")
+@Configuration
+public class EmailConfig {
+
+    @Value("${MAIL_HOST}")
+    private String emailHost;
+
+    @Value("${MAIL_USERNAME}")
+    private String username;
+
+    @Value("${MAIL_PASSWORD}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(emailHost);
+        javaMailSender.setPort(465);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setDefaultEncoding("utf-8");
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.debug", "true");
+        properties.setProperty("mail.smtp.ssl.trust", emailHost);
+        properties.setProperty("mail.smtp.ssl.enable", "true");
+
+        return properties;
+    }
+}

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),
     EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "인증 코드의 유효 기간이 만료되었습니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
 
     // MEMBER
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -6,6 +6,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // EMAIL
+    EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+    EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "인증 코드의 유효 기간이 만료되었습니다."),
+
     // MEMBER
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),

--- a/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
+++ b/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
@@ -51,8 +51,8 @@ public class ResponseDTO<T> {
             .build();
     }
 
-    public static ResponseDTO<Void> errorWithMessage(HttpStatus httpStatus, String errorMessage) {
-        return ResponseDTO.<Void>builder()
+    public static <T> ResponseDTO<T> errorWithMessage(HttpStatus httpStatus, String errorMessage) {
+        return ResponseDTO.<T>builder()
             .code(httpStatus.value())
             .message(errorMessage)
             .data(null)

--- a/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
+++ b/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
@@ -1,11 +1,13 @@
 package com.final_10aeat.global.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.final_10aeat.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResponseDTO<T> {
 
     private final int code;

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -7,12 +7,14 @@ spring:
     url: ${DATABASE_URL}
     username: root
     password: ${DATABASE_PASSWORD}
-
   jpa:
     hibernate:
       ddl-auto: update
-
   data:
     redis:
       host: ${REDIS_URL}
       port: ${REDIS_PORT}
+  mail:
+    host: ${MAIL_HOST}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,12 +8,10 @@ spring:
     url: jdbc:mysql://${LOCAL_DB_HOST}:${LOCAL_DB_PORT}/${LOCAL_DB_DATABASE}
     username: ${LOCAL_DB_ROOT_USERNAME}
     password: ${LOCAL_DB_PASSWORD}
-
   jpa:
     show-sql: true
     hibernate:
       ddl-auto: update
-
   data:
     redis:
       host: ${LOCAL_REDIS_URL}

--- a/src/main/resources/templates/email_template.html
+++ b/src/main/resources/templates/email_template.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>회원가입 인증 이메일</title>
+</head>
+<body>
+<div style="margin: 100px;">
+  <h1>안녕하세요 10aeat 입니다.</h1>
+  <p>아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+  <br>
+  <div align="center" style="border: 1px solid black; font-family: verdana">
+    <h3 style="color: #9AC1D1;">회원가입 인증 코드</h3>
+    <div style="font-size: 130%">CODE : <strong>{{authCode}}</strong></div>
+    <br>
+  </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/final_10aeat/docs/CommonDocsController.java
+++ b/src/test/java/com/final_10aeat/docs/CommonDocsController.java
@@ -1,0 +1,39 @@
+package com.final_10aeat.docs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.final_10aeat.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Rest Api 에서 에러 관련을 고지할 목적으로 만든 API 입니다. 실제 API로는 제공이 되지 않습니다.
+ */
+@RestController
+class CommonDocsController {
+
+    @PostMapping("/common/docs")
+    public ResponseDTO sample(@RequestBody @Valid SampleRequest request) {
+        return ResponseDTO.okWithDataAndMessage("응답 데이터 값", "응답 메시지");
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SampleRequest {
+
+        @NotEmpty(message = "공백이어서는 안됩니다.")
+        @JsonProperty("name")
+        private String name;
+
+        @Email(message = "이메일 양식을 다시 확인해주세요")
+        @JsonProperty("email")
+        private String email;
+    }
+}

--- a/src/test/java/com/final_10aeat/docs/CommonDocsTest.java
+++ b/src/test/java/com/final_10aeat/docs/CommonDocsTest.java
@@ -1,0 +1,42 @@
+package com.final_10aeat.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.final_10aeat.docs.CommonDocsController.SampleRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class CommonDocsTest extends RestDocsSupport {
+
+    @Override
+    public Object initController() {
+        return CommonDocsController.class;
+    }
+
+    @Test
+    void commons() throws Exception {
+
+        SampleRequest requestBody = new SampleRequest("ddd", "test@email.com");
+
+        //then
+        mockMvc.perform(post("/common/docs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestBody))
+            )
+            .andDo(
+                document("common",
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태 코드"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                    )
+                )
+            );
+    }
+}

--- a/src/test/java/com/final_10aeat/docs/RestDocsSupport.java
+++ b/src/test/java/com/final_10aeat/docs/RestDocsSupport.java
@@ -1,0 +1,45 @@
+package com.final_10aeat.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+            .apply(documentationConfiguration(provider))
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .setMessageConverters(getLocalDateTimeConverter())
+            .build();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public abstract Object initController();
+
+    public HttpMessageConverter<?> getLocalDateTimeConverter() {
+        return new MappingJackson2HttpMessageConverter(
+            new Jackson2ObjectMapperBuilder()
+                .dateFormat(new StdDateFormat())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build());
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
@@ -1,0 +1,115 @@
+package com.final_10aeat.domain.member.docs;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.final_10aeat.docs.RestDocsSupport;
+import com.final_10aeat.domain.member.controller.EmailController;
+import com.final_10aeat.domain.member.dto.request.EmailRequestDto;
+import com.final_10aeat.domain.member.dto.request.EmailVerificationRequestDto;
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.service.EmailUseCase;
+import com.final_10aeat.global.util.ResponseDTO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+public class EmailControllerDocsTest extends RestDocsSupport {
+
+    private EmailUseCase emailUseCase;
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Object initController() {
+        emailUseCase = mock(EmailUseCase.class);
+        objectMapper = new ObjectMapper();
+        return new EmailController(emailUseCase);
+    }
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(initController())
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    @DisplayName("이메일 인증 코드 전송 API 문서화")
+    @Test
+    void testSendVerificationEmail() throws Exception {
+        // given
+        EmailRequestDto emailRequest = new EmailRequestDto(
+            "test@example.com", MemberRole.TENANT, "102", "101");
+
+        // when & then
+        mockMvc.perform(post("/members/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emailRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("email-send-verification",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("인증 코드를 보낼 이메일"),
+                    fieldWithPath("role").description("회원 권한 (OWNER, TENANT)"),
+                    fieldWithPath("dong").description("동 정보"),
+                    fieldWithPath("ho").description("호 정보")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("이메일 인증 코드 검증 API 문서화")
+    @Test
+    void testVerifyEmailCode() throws Exception {
+        // given
+        EmailVerificationRequestDto verificationRequest = new EmailVerificationRequestDto(
+            "test@example.com", "6pidjym");
+
+        EmailVerificationResponseDto responseDto = new EmailVerificationResponseDto(
+            "test@example.com", "TENANT", "102", "101");
+
+        when(emailUseCase.verifyEmailCode(anyString(), anyString()))
+            .thenReturn(ResponseDTO.okWithData(responseDto));
+
+        // when & then
+        mockMvc.perform(post("/members/email/verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(verificationRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("email-verify-code",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("이메일"),
+                    fieldWithPath("code").description("인증 코드")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드"),
+                    fieldWithPath("data.email").description("이메일"),
+                    fieldWithPath("data.role").description("회원 권한 (OWNER, TENANT)"),
+                    fieldWithPath("data.dong").description("동 정보"),
+                    fieldWithPath("data.ho").description("호 정보")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
@@ -22,7 +22,6 @@ import com.final_10aeat.domain.member.dto.request.EmailVerificationRequestDto;
 import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.domain.member.service.EmailUseCase;
-import com.final_10aeat.global.util.ResponseDTO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -89,7 +88,7 @@ public class EmailControllerDocsTest extends RestDocsSupport {
             "test@example.com", "TENANT", "102", "101");
 
         when(emailUseCase.verifyEmailCode(anyString(), anyString()))
-            .thenReturn(ResponseDTO.okWithData(responseDto));
+            .thenReturn(responseDto);
 
         // when & then
         mockMvc.perform(post("/members/email/verification")

--- a/src/test/java/com/final_10aeat/domain/member/unit/LocalEmailServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/LocalEmailServiceTest.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.when;
 
 import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.exception.InvalidVerificationCodeException;
 import com.final_10aeat.domain.member.exception.VerificationCodeExpiredException;
 import com.final_10aeat.domain.member.service.LocalEmailService;
-import com.final_10aeat.global.util.ResponseDTO;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -77,11 +77,8 @@ public class LocalEmailServiceTest {
             when(valueOperations.get(email + ":code")).thenReturn(code);
             when(valueOperations.get(email + ":info")).thenReturn(userInfoJson);
 
-            ResponseDTO<EmailVerificationResponseDto> response = localEmailService.verifyEmailCode(
-                email, code);
-
-            assertEquals(HttpStatus.OK.value(), response.getCode());
-            assertEquals(expectedResponse, response.getData());
+            EmailVerificationResponseDto response = localEmailService.verifyEmailCode(email, code);
+            assertEquals(expectedResponse, response);
         }
 
         @Test
@@ -97,11 +94,9 @@ public class LocalEmailServiceTest {
             when(valueOperations.get(email + ":code")).thenReturn(wrongCode);
             when(valueOperations.get(email + ":info")).thenReturn(userInfoJson);
 
-            ResponseDTO<EmailVerificationResponseDto> response = localEmailService.verifyEmailCode(
-                email, code);
-
-            assertEquals(HttpStatus.BAD_REQUEST.value(), response.getCode());
-            assertEquals("인증번호가 일치하지 않습니다.", response.getMessage());
+            assertThrows(InvalidVerificationCodeException.class, () -> {
+                localEmailService.verifyEmailCode(email, code);
+            });
         }
 
         @Test


### PR DESCRIPTION
# ⭐️ [Feature] 이메일 인증코드 전송, 검증 기능을 구현한다.

- 이메일 인증 코드를 전송, 검증하는 기능을 구현하였습니다.
- 리소스 절약을 위해 local, test 환경에서는 실제 이메일이 발송되지 않고, 로그로 찍힙니다.
- 배포 환경(develop)에서는 실제 이메일이 발송됩니다.  
- 발송된 인증 코드의 유효시간은 하루입니다. 

## 🛠️ 변경 사항

- POST members/email : 인증코드 전송
- POST members/email/verification : 인증코드 검증

## ❗️ 관련 이슈

- #58 

## ❗️ 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-16)
- 작업 종료일: (2024-05-17)

## 💡 유의사항

- 질문이나 개선 사항이 있다면 코드리뷰 남겨주세요!
- 이메일 템플릿 디자인은 간단하게 제작하였습니다. 프론트나 UIUX 분들이 괜찮다고 하면 그대로 사용할 예정입니다.  
 
<img width="813" alt="스크린샷 2024-05-17 03 06 11" src="https://github.com/10aeat/10aeat_Backend/assets/105612931/b84c4bb2-c98d-47e9-b6ab-48acb7aeabe2">





