### PR TITLE
[Feature] Spring REST Docs 기본 세팅 및 이메일 로직 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -40,6 +38,12 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'io.github.cdimascio:java-dotenv:+'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok:1.18.28'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/docs/asciidoc/email/email-api.adoc
+++ b/src/docs/asciidoc/email/email-api.adoc
@@ -1,0 +1,41 @@
+= Email REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+
+[[Email-Send-Verification]]
+== 이메일 인증 코드 전송
+
+이메일로 인증 코드를 전송하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/email-send-verification/http-request.adoc[]
+include::{snippets}/email-send-verification/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/email-send-verification/http-response.adoc[]
+include::{snippets}/email-send-verification/response-fields.adoc[]
+
+[[Email-Verify]]
+== 이메일 인증 코드 검증
+
+전송 인증 코드, 입력 인증 코드가 일치하는지 비교하는 API 입니다.
+
+* 전송 받은 인증 코드의 유효시간은 24시간 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/email-verify-code/http-request.adoc[]
+include::{snippets}/email-verify-code/request-fields.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/email-verify-code/http-response.adoc[]
+include::{snippets}/email-verify-code/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,41 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= 10aeat API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+== API
+
+=== link:email/email-api.html[이메일 API, window=blank]
+
+== API Common Response
+
+[[overview-http-status-code]]
+=== 1. HTTP Status Code
+
+|===
+| Status code | Useage
+| `200 OK` | 요청을 성공적으로 수행
+| `201 Created` | 생성 요청 (ex: 게시글 생성)을 성공적으로 수행
+| `400 Bad Request` | API 에 기술되어 있는 요구사항에 부적합 시 발생
+| `401 Unauthorized` | 해당 API에 대한 인증 정보가 없는 경우 발생
+| `403 Forbiddon` | 해당 API에 대한 권한이 없는 경우 발생
+| `404 NotFound` | 지원하지 않는 API 경로로 요청 시 발생
+| `500 Internal Server Error` | 내부 서버 에러
+|===
+
+[[overview-common-response]]
+=== 2. API Common Response
+
+* 10aeat API 에서 공통적으로 제공하는 Response 요소들입니다.
+* 통상적인 상황이나 에러 발생시 모두 제공되는 포맷입니다.
+* null이 포함되어 있는 필드는 출력되지 않습니다.
+
+include::{snippets}/common/response-body.adoc[]
+include::{snippets}/common/response-fields.adoc[]

--- a/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
+++ b/src/main/java/com/final_10aeat/global/util/ResponseDTO.java
@@ -1,11 +1,13 @@
 package com.final_10aeat.global.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.final_10aeat.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResponseDTO<T> {
 
     private final int code;

--- a/src/test/java/com/final_10aeat/docs/CommonDocsController.java
+++ b/src/test/java/com/final_10aeat/docs/CommonDocsController.java
@@ -1,0 +1,39 @@
+package com.final_10aeat.docs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.final_10aeat.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Rest Api 에서 에러 관련을 고지할 목적으로 만든 API 입니다. 실제 API로는 제공이 되지 않습니다.
+ */
+@RestController
+class CommonDocsController {
+
+    @PostMapping("/common/docs")
+    public ResponseDTO sample(@RequestBody @Valid SampleRequest request) {
+        return ResponseDTO.okWithDataAndMessage("응답 데이터 값", "응답 메시지");
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SampleRequest {
+
+        @NotEmpty(message = "공백이어서는 안됩니다.")
+        @JsonProperty("name")
+        private String name;
+
+        @Email(message = "이메일 양식을 다시 확인해주세요")
+        @JsonProperty("email")
+        private String email;
+    }
+}

--- a/src/test/java/com/final_10aeat/docs/CommonDocsTest.java
+++ b/src/test/java/com/final_10aeat/docs/CommonDocsTest.java
@@ -1,0 +1,42 @@
+package com.final_10aeat.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.final_10aeat.docs.CommonDocsController.SampleRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class CommonDocsTest extends RestDocsSupport {
+
+    @Override
+    public Object initController() {
+        return CommonDocsController.class;
+    }
+
+    @Test
+    void commons() throws Exception {
+
+        SampleRequest requestBody = new SampleRequest("ddd", "test@email.com");
+
+        //then
+        mockMvc.perform(post("/common/docs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestBody))
+            )
+            .andDo(
+                document("common",
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태 코드"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                    )
+                )
+            );
+    }
+}

--- a/src/test/java/com/final_10aeat/docs/RestDocsSupport.java
+++ b/src/test/java/com/final_10aeat/docs/RestDocsSupport.java
@@ -1,0 +1,45 @@
+package com.final_10aeat.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+            .apply(documentationConfiguration(provider))
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .setMessageConverters(getLocalDateTimeConverter())
+            .build();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public abstract Object initController();
+
+    public HttpMessageConverter<?> getLocalDateTimeConverter() {
+        return new MappingJackson2HttpMessageConverter(
+            new Jackson2ObjectMapperBuilder()
+                .dateFormat(new StdDateFormat())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build());
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/EmailControllerDocsTest.java
@@ -1,0 +1,115 @@
+package com.final_10aeat.domain.member.docs;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.final_10aeat.docs.RestDocsSupport;
+import com.final_10aeat.domain.member.controller.EmailController;
+import com.final_10aeat.domain.member.dto.request.EmailRequestDto;
+import com.final_10aeat.domain.member.dto.request.EmailVerificationRequestDto;
+import com.final_10aeat.domain.member.dto.response.EmailVerificationResponseDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.service.EmailUseCase;
+import com.final_10aeat.global.util.ResponseDTO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+public class EmailControllerDocsTest extends RestDocsSupport {
+
+    private EmailUseCase emailUseCase;
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Object initController() {
+        emailUseCase = mock(EmailUseCase.class);
+        objectMapper = new ObjectMapper();
+        return new EmailController(emailUseCase);
+    }
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(initController())
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    @DisplayName("이메일 인증 코드 전송 API 문서화")
+    @Test
+    void testSendVerificationEmail() throws Exception {
+        // given
+        EmailRequestDto emailRequest = new EmailRequestDto(
+            "test@example.com", MemberRole.TENANT, "102", "101");
+
+        // when & then
+        mockMvc.perform(post("/members/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emailRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("email-send-verification",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("인증 코드를 보낼 이메일"),
+                    fieldWithPath("role").description("회원 권한 (OWNER, TENANT)"),
+                    fieldWithPath("dong").description("동 정보"),
+                    fieldWithPath("ho").description("호 정보")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("이메일 인증 코드 검증 API 문서화")
+    @Test
+    void testVerifyEmailCode() throws Exception {
+        // given
+        EmailVerificationRequestDto verificationRequest = new EmailVerificationRequestDto(
+            "test@example.com", "6pidjym");
+
+        EmailVerificationResponseDto responseDto = new EmailVerificationResponseDto(
+            "test@example.com", "TENANT", "102", "101");
+
+        when(emailUseCase.verifyEmailCode(anyString(), anyString()))
+            .thenReturn(ResponseDTO.okWithData(responseDto));
+
+        // when & then
+        mockMvc.perform(post("/members/email/verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(verificationRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("email-verify-code",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("이메일"),
+                    fieldWithPath("code").description("인증 코드")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드"),
+                    fieldWithPath("data.email").description("이메일"),
+                    fieldWithPath("data.role").description("회원 권한 (OWNER, TENANT)"),
+                    fieldWithPath("data.dong").description("동 정보"),
+                    fieldWithPath("data.ho").description("호 정보")
+                )
+            ));
+    }
+}


### PR DESCRIPTION
# ⭐️ [Feature] Spring REST Docs 기본 세팅 및 이메일 로직 테스트 코드 추가


## 🛠️ 변경 사항

- Spring REST Docs 활용을 위한 기본 설정을 추가하였습니다.
- 공통 응답을 REST Docs을 활용해 문서화 했습니다.
- REST Docs 테스트 지원을 위한 RestDocsSupport 클래스를 추가하였습니다.
- Asciidoctor API 문서 템플릿 파일과 이메일 REST API 파일을 추가하였습니다.
- LocalEmailService 테스트 코드를 추가하였습니다.
- lombok 관련 의존성을 추가하였습니다.

## ❗️ 관련 이슈

- #59 

## ❗️ 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-17)
- 작업 종료일: (2024-05-17)


