### PR TITLE
[Refactor] 로그인을 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -1,12 +1,11 @@
 package com.final_10aeat.domain.member.controller;
 
-import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.service.MemberService;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +20,7 @@ public class MemberController {
     @PostMapping("/register")
     public ResponseDTO<Void> register(
             @RequestBody MemberRegisterRequestDto request
-    ){
+    ) {
         memberService.register(request);
         return ResponseDTO.ok();
     }
@@ -29,9 +28,9 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseDTO<Void> login(
             HttpServletResponse response,
-            @RequestBody MemberLoginRequestDto request){
+            @RequestBody MemberLoginRequestDto request) {
         String token = memberService.login(request);
-        response.setHeader(HttpHeaders.AUTHORIZATION, token);
+        response.setHeader("accessToken", token);
         return ResponseDTO.ok();
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -50,7 +50,7 @@ public class MemberService {
             throw new MemberNotExistException();
         }
 
-        return jwtTokenGenerator.createJwtToken(request.email());
+        return jwtTokenGenerator.createJwtToken(request.email(),member.getRole());
     }
 
     private Boolean passwordMatcher(final String requestPassword, final Member member) {

--- a/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
+++ b/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.final_10aeat.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -33,7 +34,8 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         auth -> auth
-                                .anyRequest().permitAll()
+                                .requestMatchers(HttpMethod.POST,"/members/**").permitAll()
+                                .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
@@ -35,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain
     ) throws ServletException, IOException {
         //헤더에서 토큰 값을 읽어오는 과정
-        String accessToken = request.getHeader("accessToken");//기본적으로 포함되는 것
+        String accessToken = request.getHeader("accessToken");//
         if(accessToken!=null){
             Authentication authentication = getEmailPassword(accessToken);
 
@@ -43,7 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     .setAuthentication(authentication);
         }
 
-        filterChain.doFilter(request, response); //이 필터 끝났으니 다음 필터로 진행해라
+        filterChain.doFilter(request, response);//필터 종료 후 다음 필터로 진행
 
     }
 

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,7 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /**
-     //@AuthenticationPrincipal 컨트롤러에서 Member 사용 시 이 어노테이션으로 바로 파싱 가능
+     //컨트롤러에서 Member 사용 시 @AuthenticationPrincipal 어노테이션으로 MemberPrincipal을 불러와 사용
      */
 
     private final JwtTokenGenerator jwtTokenGenerator;
@@ -36,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain
     ) throws ServletException, IOException {
         //헤더에서 토큰 값을 읽어오는 과정
-        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);//기본적으로 포함되는 것
+        String accessToken = request.getHeader("accessToken");//기본적으로 포함되는 것
         if(accessToken!=null){
             Authentication authentication = getEmailPassword(accessToken);
 

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.global.security.jwt;
 
 
+import com.final_10aeat.domain.member.entity.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.stereotype.Component;
@@ -29,9 +30,10 @@ public class JwtTokenGenerator {
     private final Long accessExpiredTimeMills = 1000 * 60 * 30L;
 
 
-    public String createJwtToken(String email) {
+    public String createJwtToken(String email, MemberRole memberRole) {
         return Jwts.builder()
                 .claim("email", email)
+                .claim("role",memberRole)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessExpiredTimeMills))
                 .signWith(key)
@@ -43,6 +45,10 @@ public class JwtTokenGenerator {
         return claims.get("email", String.class);
     }
 
+    public String getRole(String token) {
+        Claims claims = extractClaim(token);
+        return claims.get("role", String.class);
+    }
 
     private Claims extractClaim(String token) {
         return Jwts.parser()

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
@@ -26,7 +26,7 @@ public class JwtTokenGenerator {
 
     //TODO: yml 파일이 구체화 된 후에 주입으로 변경
 //    @Value()
-    private final Long accessExpiredTimeMills = 1000 * 30L;
+    private final Long accessExpiredTimeMills = 1000 * 60 * 30L;
 
 
     public String createJwtToken(String email) {

--- a/src/main/java/com/final_10aeat/global/security/principal/MemberPrincipal.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/MemberPrincipal.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.global.security.principal;
 
 import com.final_10aeat.domain.member.entity.Member;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,6 +11,7 @@ import java.util.Collection;
 @RequiredArgsConstructor
 public class MemberPrincipal implements UserDetails {
 
+    @Getter
     private final Member member;
 
     @Override


### PR DESCRIPTION
# Pull Request 요약

- Member 로그인 로직에서 보완이 필요한 부분들을 일부 수정했습니다

## 변경 사항

- 엑세스 토큰 헤더 AUTHORIZATION -> accessToken 으로 변경
- 토큰 claim에 role 추가
- POST /members/** 경로 허용, 그 외 로그인 필요로 시큐리티 경로 설정
- 토큰 지속시간 30s -> 30m
- MemberPrincipal에 Getter 추가
- 사용하지 않는 의존성 제거

## 관련 이슈

- #62 

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [X] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-17)
- 작업 종료일: (2024-05-18)

## 유의사항

- DevTool 의존성 삭제했습니다!

## 참고문헌
