### PR TITLE
[Feat] 서버 상태를 확인 할 수 있다

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,4 +74,15 @@ jobs:
             docker stop my-container
             docker rm my-container
             docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:develop
-            docker run --name my-container -e REDIS_URL=${{ secrets.REDIS_URL }} -e REDIS_PORT=${{ secrets.REDIS_PORT }} -e DATABASE_URL=${{ secrets.DB_URL }} -e DATABASE_PASSWORD=${{ secrets.DB_PASSWORD }} -e MAIL_HOST=${{ secrets.MAIL_HOST }} -e MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} -e MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} -p 80:8080 -d ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:develop
+            docker run --name my-container \
+            -e REDIS_URL=${{ secrets.REDIS_URL }} \
+            -e REDIS_PORT=${{ secrets.REDIS_PORT }} \
+            -e DATABASE_URL=${{ secrets.DB_URL }} \
+            -e DATABASE_PASSWORD=${{ secrets.DB_PASSWORD }} \
+            -e MAIL_HOST=${{ secrets.MAIL_HOST }} \
+            -e MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} \
+            -e MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} \
+            -p 80:8080 -d ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:develop
+            sleep 60
+            curl -s http://10aeat.com/health/server
+            curl -s http://10aeat.com/health/redis

--- a/src/main/java/com/final_10aeat/controller/HealthCheckController.java
+++ b/src/main/java/com/final_10aeat/controller/HealthCheckController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/health")
 @RequiredArgsConstructor
 public class HealthCheckController {
+
     private final StringRedisTemplate redisTemplate;
 
     @GetMapping("/server")

--- a/src/main/java/com/final_10aeat/controller/HealthCheckController.java
+++ b/src/main/java/com/final_10aeat/controller/HealthCheckController.java
@@ -1,0 +1,25 @@
+package com.final_10aeat.controller;
+
+import com.final_10aeat.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health")
+@RequiredArgsConstructor
+public class HealthCheckController {
+    private final StringRedisTemplate redisTemplate;
+
+    @GetMapping("/server")
+    public ResponseDTO<Void> serverHealthCheck(){
+        return ResponseDTO.ok();
+    }
+
+    @GetMapping("/redis")
+    public ResponseDTO<?> redisHealthCheck(){
+        return ResponseDTO.okWithData(redisTemplate.getConnectionFactory().getConnection().ping());
+    }
+}

--- a/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
+++ b/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
@@ -34,8 +34,8 @@ public class SecurityConfig {
             .cors(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(
                 auth -> auth
-                    .requestMatchers(HttpMethod.POST, "/members/register", "/members/login")
-                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/members/register", "/members/login").permitAll()
+                    .requestMatchers(HttpMethod.GET,"/health/**").permitAll()
                     .requestMatchers("/docs/**").permitAll()
                     .anyRequest().authenticated()
             )


### PR DESCRIPTION
# Pull Request 요약

/health/** 경로를 통해 Redis 연결 상태와 서버 가동 여부를 알 수 있습니다

## 변경 사항
- HealthCheckController : 상태 확인용 컨트롤러를 만들어 domain과 같은레벨의 controller 패키지를 작성 했습니다
- ci-cd.yml 기존 스크립트 수정: 길어지면서 가독성이 나빠진 스크립트를 여러줄로 변경하여 가독성을 올렸습니다
- ci-cd.yml : healthcheck를 서버 가동이후 자동으로 진행하여 서버 상태를 바로 확인 가능합니다
## 관련 이슈

- #72 

## 개발 유형

- [ ] 버그 수정
- [X] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-19)
- 작업 종료일: (2024-05-19)

## 유의사항

- 서버가 켜지는것을 고려해 sleep 60 명령어를 사용하여 배포 스크립트 진행이 조금 길어졌습니다
- 추후 액츄에이터를 사용하게 된다면 서버 헬스 체크 경로는 삭제 가능합니다

## 참고문헌
