### PR TITLE
[Feature] 회원가입, 탈퇴를 구현한다.

### DIFF
--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -18,7 +18,7 @@ public class MemberController {
 
     @PostMapping()
     public ResponseDTO<Void> register(
-            @RequestBody MemberRegisterRequestDto request
+            @RequestBody @Valid MemberRegisterRequestDto request
     ) {
         memberService.register(request);
         return ResponseDTO.ok();

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping("/register")
+    @PostMapping
     public ResponseDTO<Void> register(
             @RequestBody MemberRegisterRequestDto request
     ){
@@ -33,7 +33,7 @@ public class MemberController {
         return ResponseDTO.ok();
     }
 
-    @DeleteMapping("/delete/v1/users")
+    @DeleteMapping
     public ResponseDTO<Void> withdraw(
             @RequestBody MemberWithdrawRequestDto request
     ){

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -1,15 +1,14 @@
 package com.final_10aeat.domain.member.controller;
 
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.service.MemberService;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,7 +19,7 @@ public class MemberController {
     @PostMapping("/register")
     public ResponseDTO<Void> register(
             @RequestBody MemberRegisterRequestDto request
-    ) {
+    ){
         memberService.register(request);
         return ResponseDTO.ok();
     }
@@ -28,9 +27,17 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseDTO<Void> login(
             HttpServletResponse response,
-            @RequestBody MemberLoginRequestDto request) {
+            @RequestBody MemberLoginRequestDto request){
         String token = memberService.login(request);
-        response.setHeader("accessToken", token);
+        response.setHeader(HttpHeaders.AUTHORIZATION, token);
+        return ResponseDTO.ok();
+    }
+
+    @DeleteMapping("/delete/v1/users")
+    public ResponseDTO<Void> withdraw(
+            @RequestBody MemberWithdrawRequestDto request
+    ){
+        memberService.withdraw(request);
         return ResponseDTO.ok();
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -2,14 +2,13 @@ package com.final_10aeat.domain.member.controller;
 
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.service.MemberService;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping("/register")
+    @PostMapping()
     public ResponseDTO<Void> register(
             @RequestBody MemberRegisterRequestDto request
     ) {
@@ -31,6 +30,14 @@ public class MemberController {
             @RequestBody MemberLoginRequestDto request) {
         String token = memberService.login(request);
         response.setHeader("accessToken", token);
+        return ResponseDTO.ok();
+    }
+
+    @DeleteMapping()
+    public ResponseDTO<Void> withdraw(
+            @RequestBody @Valid MemberWithdrawRequestDto request
+    ){
+        memberService.withdraw(request);
         return ResponseDTO.ok();
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping()
+    @PostMapping
     public ResponseDTO<Void> register(
             HttpServletResponse response,
             @RequestBody @Valid MemberRegisterRequestDto request
@@ -32,13 +32,13 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseDTO<Void> login(
             HttpServletResponse response,
-            @RequestBody MemberLoginRequestDto request) {
+            @RequestBody @Valid MemberLoginRequestDto request) {
         String token = memberService.login(request);
         response.setHeader("accessToken", token);
         return ResponseDTO.ok();
     }
 
-    @DeleteMapping()
+    @DeleteMapping
     public ResponseDTO<Void> withdraw(
             @RequestBody @Valid MemberWithdrawRequestDto request
     ){

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -18,9 +18,14 @@ public class MemberController {
 
     @PostMapping()
     public ResponseDTO<Void> register(
+            HttpServletResponse response,
             @RequestBody @Valid MemberRegisterRequestDto request
     ) {
-        memberService.register(request);
+        MemberLoginRequestDto loginDto = memberService.register(request);
+
+        String token = memberService.login(loginDto);
+        response.setHeader("accessToken", token);
+
         return ResponseDTO.ok();
     }
 

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -17,5 +17,7 @@ public record MemberRegisterRequestDto(
         @NotBlank
         String ho,
         @NotNull
-        MemberRole memberRole
+        MemberRole memberRole,
+        @NotNull
+        Boolean isTermAgreed
 ) { }

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -5,6 +5,7 @@ import com.final_10aeat.domain.member.entity.MemberRole;
 public record MemberRegisterRequestDto(
         String email,
         String password,
+        String name,
         String dong,
         String ho,
         MemberRole memberRole

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -1,6 +1,9 @@
 package com.final_10aeat.domain.member.dto.request;
 
+import com.final_10aeat.domain.member.entity.MemberRole;
+
 public record MemberRegisterRequestDto(
         String email,
-        String password
+        String password,
+        MemberRole memberRole
 ) { }

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -1,12 +1,21 @@
 package com.final_10aeat.domain.member.dto.request;
 
 import com.final_10aeat.domain.member.entity.MemberRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record MemberRegisterRequestDto(
+        @Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$")
         String email,
+        @NotBlank
         String password,
+        @NotBlank
         String name,
+        @NotBlank
         String dong,
+        @NotBlank
         String ho,
+        @NotNull
         MemberRole memberRole
 ) { }

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -5,5 +5,7 @@ import com.final_10aeat.domain.member.entity.MemberRole;
 public record MemberRegisterRequestDto(
         String email,
         String password,
+        String dong,
+        String ho,
         MemberRole memberRole
 ) { }

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
@@ -1,9 +1,10 @@
 package com.final_10aeat.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record MemberWithdrawRequestDto(
-        @NotBlank
+        @Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$")
         String email,
         @NotBlank
         String password

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
@@ -1,7 +1,11 @@
 package com.final_10aeat.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record MemberWithdrawRequestDto(
+        @NotBlank
         String email,
+        @NotBlank
         String password
 ) {
 }

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberWithdrawRequestDto.java
@@ -1,0 +1,7 @@
+package com.final_10aeat.domain.member.dto.request;
+
+public record MemberWithdrawRequestDto(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/final_10aeat/domain/member/entity/Member.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.final_10aeat.domain.member.entity;
 import com.final_10aeat.domain.admin.entity.Office;
 import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Set;
 import lombok.*;
 
@@ -48,4 +49,8 @@ public class Member extends SoftDeletableBaseTimeEntity {
         inverseJoinColumns = @JoinColumn(name = "office_id")
     )
     private Set<Office> offices;
+
+    public void delete(LocalDateTime currentTime){
+        super.delete(currentTime);
+    }
 }

--- a/src/main/java/com/final_10aeat/domain/member/entity/Member.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/Member.java
@@ -34,6 +34,9 @@ public class Member extends SoftDeletableBaseTimeEntity {
     @Column(nullable = false)
     private MemberRole role;
 
+    @Column
+    private Boolean isTermAgreed;
+
     @ManyToMany
     @JoinTable(
         name = "member_building",

--- a/src/main/java/com/final_10aeat/domain/member/exception/DisagreementException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/DisagreementException.java
@@ -1,0 +1,13 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class DisagreementException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.DISAGREE_TERM;
+
+    public DisagreementException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/exception/MemberMissMatchException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/MemberMissMatchException.java
@@ -1,0 +1,13 @@
+package com.final_10aeat.domain.member.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class MemberMissMatchException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.MEMBER_MISMATCH;
+
+    public MemberMissMatchException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/member/repository/BuildingInfoRepository.java
+++ b/src/main/java/com/final_10aeat/domain/member/repository/BuildingInfoRepository.java
@@ -1,0 +1,9 @@
+package com.final_10aeat.domain.member.repository;
+
+import com.final_10aeat.domain.member.entity.BuildingInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BuildingInfoRepository extends JpaRepository<BuildingInfo, Long> {
+}

--- a/src/main/java/com/final_10aeat/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/final_10aeat/domain/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Boolean existsByEmail(String email);
+    Boolean existsByEmailAndDeletedAtIsNull(String email);
 
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.MemberDuplicatedException;
+import com.final_10aeat.domain.member.exception.MemberMissMatchException;
 import com.final_10aeat.domain.member.exception.MemberNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
@@ -27,40 +28,36 @@ public class MemberService {
     private final JwtTokenGenerator jwtTokenGenerator;
     private final BuildingInfoRepository buildingInfoRepository;
 
-    //TODO: 응답 값에 대한 부분은 프론트와 논의 필요
     public void register(MemberRegisterRequestDto request) {
-        // 1. 유효성 검사
-        if (memberRepository.existsByEmail(request.email())) {
+
+        if (memberRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
             throw new MemberDuplicatedException();
         }
 
-        // 2. 비밀번호 인코딩
         String password = passwordEncoder.encode(request.password());
 
-        // 3. dong, ho를 BuildingInfo로 변환, member로 변환
         BuildingInfo buildingInfo = BuildingInfo.builder()
                 .dong(request.dong())
                 .ho(request.ho())
                 .office(null)
                 .build();
 
-        //BuildingInfo를 먼저 저장해준다.
         BuildingInfo savedBuildingInfo = buildingInfoRepository.save(buildingInfo);
 
         Member member = Member.builder()
                 .email(request.email())
                 .password(password)
+                .name(request.name())
                 .role(request.memberRole())
                 .buildingInfos(Set.of(savedBuildingInfo))
                 .build();
 
-        // 4. save
         memberRepository.save(member);
     }
 
     @Transactional(readOnly = true)
     public String login(MemberLoginRequestDto request) {
-        Member member = memberRepository.findByEmail(request.email())
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
                 .orElseThrow(MemberNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
@@ -71,11 +68,11 @@ public class MemberService {
     }
 
     public void withdraw(MemberWithdrawRequestDto request) {
-        Member member = memberRepository.findByEmail(request.email())
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
                 .orElseThrow(MemberNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
-            throw new MemberNotExistException();
+            throw new MemberMissMatchException();
         }
 
         member.delete(LocalDateTime.now());

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.member.service;
 
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.MemberDuplicatedException;
 import com.final_10aeat.domain.member.exception.MemberNotExistException;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +37,7 @@ public class MemberService {
         Member member = Member.builder()
                 .email(request.email())
                 .password(password)
+                .role(request.memberRole())
                 .build();
 
         // 4. save
@@ -51,6 +54,17 @@ public class MemberService {
         }
 
         return jwtTokenGenerator.createJwtToken(request.email(),member.getRole());
+    }
+
+    public void withdraw(MemberWithdrawRequestDto request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(MemberNotExistException::new);
+
+        if (!passwordMatcher(request.password(), member)) {
+            throw new MemberNotExistException();
+        }
+
+        member.delete(LocalDateTime.now());
     }
 
     private Boolean passwordMatcher(final String requestPassword, final Member member) {

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -3,9 +3,11 @@ package com.final_10aeat.domain.member.service;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
+import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.MemberDuplicatedException;
 import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenGenerator jwtTokenGenerator;
+    private final BuildingInfoRepository buildingInfoRepository;
 
     //TODO: 응답 값에 대한 부분은 프론트와 논의 필요
     public void register(MemberRegisterRequestDto request) {
@@ -33,11 +37,21 @@ public class MemberService {
         // 2. 비밀번호 인코딩
         String password = passwordEncoder.encode(request.password());
 
-        // 3. member로 변환
+        // 3. dong, ho를 BuildingInfo로 변환, member로 변환
+        BuildingInfo buildingInfo = BuildingInfo.builder()
+                .dong(request.dong())
+                .ho(request.ho())
+                .office(null)
+                .build();
+
+        //BuildingInfo를 먼저 저장해준다.
+        BuildingInfo savedBuildingInfo = buildingInfoRepository.save(buildingInfo);
+
         Member member = Member.builder()
                 .email(request.email())
                 .password(password)
                 .role(request.memberRole())
+                .buildingInfos(Set.of(savedBuildingInfo))
                 .build();
 
         // 4. save

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
     private final JwtTokenGenerator jwtTokenGenerator;
     private final BuildingInfoRepository buildingInfoRepository;
 
-    public void register(MemberRegisterRequestDto request) {
+    public MemberLoginRequestDto register(MemberRegisterRequestDto request) {
 
         if (memberRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
             throw new MemberDuplicatedException();
@@ -53,6 +53,8 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+
+        return new MemberLoginRequestDto(request.email(), request.password());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.member.exception.DisagreementException;
 import com.final_10aeat.domain.member.exception.MemberDuplicatedException;
 import com.final_10aeat.domain.member.exception.MemberMissMatchException;
 import com.final_10aeat.domain.member.exception.MemberNotExistException;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -34,6 +36,10 @@ public class MemberService {
             throw new MemberDuplicatedException();
         }
 
+        if (!request.isTermAgreed()){
+            throw new DisagreementException();
+        }
+
         String password = passwordEncoder.encode(request.password());
 
         BuildingInfo buildingInfo = BuildingInfo.builder()
@@ -50,6 +56,7 @@ public class MemberService {
                 .name(request.name())
                 .role(request.memberRole())
                 .buildingInfos(Set.of(savedBuildingInfo))
+                .isTermAgreed(request.isTermAgreed())
                 .build();
 
         memberRepository.save(member);

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -12,11 +12,15 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "인증 코드의 유효 기간이 만료되었습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
 
+    // OFFICE
+    OFFICE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 건물입니다."),
+
     // MEMBER
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
     MEMBER_MISMATCH(HttpStatus.CONFLICT, "일치하지 않는 사용자입니다."),
+    DISAGREE_TERM(HttpStatus.CONFLICT, "약관에 동의해야 합니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
+    MEMBER_MISMATCH(HttpStatus.CONFLICT, "일치하지 않는 사용자입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
@@ -15,7 +15,7 @@ public class MemberDetailsProvider implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        return new MemberPrincipal(memberRepository.findByEmail(email)
+        return new MemberPrincipal(memberRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(MemberNotExistException::new));
     }
 }

--- a/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
@@ -56,7 +56,7 @@ class MemberServiceTest {
             //given
             String accessToken = "token";
 
-            given(memberRepository.findByEmail(email))
+            given(memberRepository.findByEmailAndDeletedAtIsNull(email))
                 .willReturn(Optional.of(member));
             given(passwordEncoder.matches(password, member.getPassword()))
                 .willReturn(Boolean.TRUE);
@@ -74,7 +74,7 @@ class MemberServiceTest {
         @DisplayName("존재하지 않는 이메일을 요청하여 실패한다.")
         void _DontExistEmail() {
             //given
-            given(memberRepository.findByEmail(email))
+            given(memberRepository.findByEmailAndDeletedAtIsNull(email))
                 .willReturn(Optional.empty());
 
             // when & then
@@ -87,7 +87,7 @@ class MemberServiceTest {
         @DisplayName("비밀번호가 달라 요청에 실패한다.")
         void _PasswordDoesNotMatches() {
             //given
-            given(memberRepository.findByEmail(email))
+            given(memberRepository.findByEmailAndDeletedAtIsNull(email))
                 .willReturn(Optional.of(member));
             given(passwordEncoder.matches(password, member.getPassword()))
                 .willReturn(Boolean.FALSE);

--- a/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
@@ -1,0 +1,102 @@
+package com.final_10aeat.domain.member.unit;
+
+import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.entity.BuildingInfo;
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.exception.MemberDuplicatedException;
+import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
+import com.final_10aeat.domain.member.repository.MemberRepository;
+import com.final_10aeat.domain.member.service.MemberService;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+public class RegisterServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private BuildingInfoRepository buildingInfoRepository;
+    @InjectMocks
+    private MemberService memberService;
+
+    private final String email = "test@test.com";
+    private final String password = "password";
+    private final String name = "spring";
+    private final String dong = "102동";
+    private final String ho = "2212호";
+    private final MemberRole role = MemberRole.TENANT;
+
+
+    private final MemberRegisterRequestDto request = new MemberRegisterRequestDto(email, password, name, dong, ho, role);
+    private final BuildingInfo buildingInfo = BuildingInfo.builder()
+            .dong(dong)
+            .ho(ho)
+            .office(null)
+            .build();
+    private final Member member = Member.builder()
+            .id(1L)
+            .email(email)
+            .password(password)
+            .name(name)
+            .role(role)
+            .buildingInfos(Set.of(BuildingInfo.builder()
+                    .dong(dong)
+                    .ho(ho)
+                    .office(null)
+                    .build()))
+            .build();
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("register()는")
+    class Context_Register {
+
+        @Test
+        @DisplayName("회원가입에 성공한다.")
+        void _willSuccess(){
+            //given
+            given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
+            given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
+            given(memberRepository.save(any(Member.class))).willReturn(member);
+            given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(false);
+
+            //when
+            MemberLoginRequestDto loginRequest = memberService.register(request);
+
+            //then
+            assertEquals(new MemberLoginRequestDto(email, password), loginRequest);
+        }
+
+        @Test
+        @DisplayName("이메일이 중복된 회원의 가입을 시도하여 실패한다.")
+        void _willDuplicatedEmail(){
+            //given
+            given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
+            given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
+            given(memberRepository.save(any(Member.class))).willReturn(member);
+            given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(true);
+
+            //then
+            Assertions.assertThrows(MemberDuplicatedException.class,
+                    () -> memberService.register(request));
+        }
+
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -2,29 +2,74 @@ package com.final_10aeat.domain.member.unit;
 
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
+import com.final_10aeat.domain.member.entity.BuildingInfo;
+import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.exception.MemberMissMatchException;
+import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
+import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.member.service.MemberService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.mockito.Mockito.verify;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
 
 public class WithdrawServiceTest {
 
-    @Mock
+    @InjectMocks
     private MemberService memberService;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private BuildingInfoRepository buildingInfoRepository;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
         String email = "spring";
-        String password= "spring";
-        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "103동", "2212호", MemberRole.TENANT);
+        String password = "spring";
+
+        BuildingInfo buildingInfo = BuildingInfo.builder()
+                .dong("102동")
+                .ho("2212호")
+                .office(null)
+                .build();
+
+        when(buildingInfoRepository.save(any(BuildingInfo.class))).thenReturn(buildingInfo);
+
+        Member member = Member.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .name("spring")
+                .role(MemberRole.TENANT)
+                .buildingInfos(Set.of(BuildingInfo.builder()
+                        .dong("102동")
+                        .ho("2212호")
+                        .office(null)
+                        .build()))
+                .build();
+
+        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "스프링", "103동", "2212호", MemberRole.TENANT);
+
         memberService.register(requestDto);
+
+        when(memberRepository.findByEmailAndDeletedAtIsNull(email)).thenReturn(Optional.of(member));
+        when(memberRepository.existsByEmailAndDeletedAtIsNull(email)).thenReturn(true);
+        when(passwordEncoder.matches(password, member.getPassword())).thenReturn(true);
     }
 
     @Test
@@ -36,6 +81,27 @@ public class WithdrawServiceTest {
 
         memberService.withdraw(memberRequest);
 
-        verify(memberService).withdraw(memberRequest);
+        verify(memberRepository).findByEmailAndDeletedAtIsNull(email);
+        verify(memberRepository).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("다른 회원의 탈퇴를 시도한다.-사용자 불일치 오류 발생")
+    void _willMissMatch() {
+        String email = "spring";
+        String password = "asdasdasd";
+        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+
+        Assertions.assertThrows(MemberMissMatchException.class, () -> memberService.withdraw(memberRequest));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴하려는 계정이 존재하지 않는다.")
+    void _willNotExist() {
+        String email = "2222";
+        String password = "2222";
+        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+
+        Assertions.assertThrows(MemberNotExistException.class, () -> memberService.withdraw(memberRequest));
     }
 }

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -52,7 +52,7 @@ public class WithdrawServiceTest {
                     .office(null)
                     .build()))
             .build();
-    private final MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "스프링", "103동", "2212호", MemberRole.TENANT);
+    private final MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "spring", "103동", "2212호", MemberRole.TENANT, true);
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -10,10 +10,7 @@ import com.final_10aeat.domain.member.exception.MemberNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.member.service.MemberService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -35,35 +32,32 @@ public class WithdrawServiceTest {
     @Mock
     private BuildingInfoRepository buildingInfoRepository;
 
+    private final String email = "spring";
+    private final String password = "spring";
+    private final BuildingInfo buildingInfo = BuildingInfo.builder()
+            .dong("102동")
+            .ho("2212호")
+            .office(null)
+            .build();
+    private final Member member = Member.builder()
+            .id(1L)
+            .email(email)
+            .password(password)
+            .name("spring")
+            .role(MemberRole.TENANT)
+            .buildingInfos(Set.of(BuildingInfo.builder()
+                    .dong("102동")
+                    .ho("2212호")
+                    .office(null)
+                    .build()))
+            .build();
+    private final MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "스프링", "103동", "2212호", MemberRole.TENANT);
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        String email = "spring";
-        String password = "spring";
-
-        BuildingInfo buildingInfo = BuildingInfo.builder()
-                .dong("102동")
-                .ho("2212호")
-                .office(null)
-                .build();
-
         when(buildingInfoRepository.save(any(BuildingInfo.class))).thenReturn(buildingInfo);
-
-        Member member = Member.builder()
-                .id(1L)
-                .email(email)
-                .password(password)
-                .name("spring")
-                .role(MemberRole.TENANT)
-                .buildingInfos(Set.of(BuildingInfo.builder()
-                        .dong("102동")
-                        .ho("2212호")
-                        .office(null)
-                        .build()))
-                .build();
-
-        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "스프링", "103동", "2212호", MemberRole.TENANT);
 
         memberService.register(requestDto);
 
@@ -72,36 +66,40 @@ public class WithdrawServiceTest {
         when(passwordEncoder.matches(password, member.getPassword())).thenReturn(true);
     }
 
-    @Test
-    @DisplayName("회원 탈퇴 메서드가 정상 작동한다.")
-    void _willSuccess() {
-        String email = "spring";
-        String password = "spring";
-        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+    @Nested
+    @DisplayName("withdraw()는 ")
+    class Context_Withdraw{
+        @Test
+        @DisplayName("회원 탈퇴를 성공한다.")
+        void _willSuccess() {
+            String email = "spring";
+            String password = "spring";
+            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
 
-        memberService.withdraw(memberRequest);
+            memberService.withdraw(memberRequest);
 
-        verify(memberRepository).findByEmailAndDeletedAtIsNull(email);
-        verify(memberRepository).save(any(Member.class));
-    }
+            verify(memberRepository).findByEmailAndDeletedAtIsNull(email);
+            verify(memberRepository).save(any(Member.class));
+        }
 
-    @Test
-    @DisplayName("다른 회원의 탈퇴를 시도한다.-사용자 불일치 오류 발생")
-    void _willMissMatch() {
-        String email = "spring";
-        String password = "asdasdasd";
-        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+        @Test
+        @DisplayName("일치하지 않는 사용자의 탈퇴를 시도하여 실패한다.")
+        void _willMissMatch() {
+            String email = "spring";
+            String password = "asdasdasd";
+            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
 
-        Assertions.assertThrows(MemberMissMatchException.class, () -> memberService.withdraw(memberRequest));
-    }
+            Assertions.assertThrows(MemberMissMatchException.class, () -> memberService.withdraw(memberRequest));
+        }
 
-    @Test
-    @DisplayName("회원 탈퇴하려는 계정이 존재하지 않는다.")
-    void _willNotExist() {
-        String email = "2222";
-        String password = "2222";
-        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+        @Test
+        @DisplayName("회원 탈퇴하려는 계정이 존재하지 않아 실패한다.")
+        void _willNotExist() {
+            String email = "2222";
+            String password = "2222";
+            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
 
-        Assertions.assertThrows(MemberNotExistException.class, () -> memberService.withdraw(memberRequest));
+            Assertions.assertThrows(MemberNotExistException.class, () -> memberService.withdraw(memberRequest));
+        }
     }
 }

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -23,7 +23,7 @@ public class WithdrawServiceTest {
 
         String email = "spring";
         String password= "spring";
-        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, MemberRole.TENANT);
+        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "103동", "2212호", MemberRole.TENANT);
         memberService.register(requestDto);
     }
 

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -1,0 +1,41 @@
+package com.final_10aeat.domain.member.unit;
+
+import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
+import com.final_10aeat.domain.member.entity.MemberRole;
+import com.final_10aeat.domain.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.verify;
+
+public class WithdrawServiceTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        String email = "spring";
+        String password= "spring";
+        MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, MemberRole.TENANT);
+        memberService.register(requestDto);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 메서드가 정상 작동한다.")
+    void _willSuccess() {
+        String email = "spring";
+        String password = "spring";
+        MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, password);
+
+        memberService.withdraw(memberRequest);
+
+        verify(memberService).withdraw(memberRequest);
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -63,7 +63,7 @@ public class WithdrawServiceTest {
         memberService.register(requestDto);
 
         given(memberRepository.findByEmailAndDeletedAtIsNull(email)).willReturn(Optional.of(member));
-        given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(true);
+        given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(false);
         given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
     }
 


### PR DESCRIPTION
# Pull Request 요약

- 회원 가입 탈퇴를 구현한다.

## 변경 사항

### 회원 탈퇴
-  - Member: 논리 삭제를 위해 상속받은 클래스의 delete메서드를 호출하는 삭제 메서드를 추가한다.
- MemberController: 삭제 메서드를 추가한다.
- MemberRegisterRequestDto: MemberRole을 추가한다.
- MemberService: register 메서드에서 member 빌더에 memberRole을 추가한다. withdraw 메서드를 추가한다.
- MemberWithdrawRequestDto: api 명세서에 따라 requsetDto를 추가한다.

### 회원 가입
- MemberRegisterRequestDto: 동, 호수, MemberRole 추가했습니다.
- MemberService: BuildingInfo의 Office에 대한 정보를 어떻게 저장하면 좋을 지에 대해서 논의가 필요할 것 같습니다. 이 부분을 우선 null로 처리하고 회원가입 로직 작성했습니다.
- BuildingInfoRepository: 회원 가입 시 빌딩 정보 저장을 위해 추가했습니다.

## 관련 이슈

- #63 

## 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-17)
- 작업 종료일: (2024-05-20)

## 유의사항

- 디스코드에서 잠시 얘기했었는데, 자바 코드에서 BuildingInfo의 Office를 저장하는 방식에 대해서 논의가 필요할 것 같습니다!
- 날카로운(?) 코드 리뷰 부탁드립니다ㅋㅋㅋ....달게 받겠습니다!!! 문제가 있는 것 같으나 지식 부족으로 못 찾는 것 같아서...

## 참고문헌

- 이 PR을 작성하며 참조한 문헌이나 가이드가 있다면 여기에 링크를 추가하세요.
