### PR TITLE
[Refactor] Admin, Member를 Loginable로 추상화한다

### DIFF
--- a/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
+++ b/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
@@ -1,42 +1,24 @@
 package com.final_10aeat.domain.admin.entity;
 
 import com.final_10aeat.domain.member.entity.MemberRole;
-import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import com.final_10aeat.global.entity.Loginable;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
-@Builder
 @Table(name = "admin")
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Admin extends SoftDeletableBaseTimeEntity {
+public class Admin extends Loginable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(unique = true)
-    private String email;
-
-    @Column
-    private String password;
 
     @Column
     private String name;
@@ -55,11 +37,20 @@ public class Admin extends SoftDeletableBaseTimeEntity {
 
     private String affiliation;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private MemberRole role = MemberRole.ADMIN;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "office_id")
     private Office office;
+
+    @Builder
+    private Admin(String email, String password, Long id, String name, String phoneNumber, LocalDateTime lunchBreakStart, LocalDateTime lunchBreakEnd, String adminOffice, String affiliation, Office office) {
+        super(email, password, MemberRole.ADMIN);
+        this.id = id;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.lunchBreakStart = lunchBreakStart;
+        this.lunchBreakEnd = lunchBreakEnd;
+        this.adminOffice = adminOffice;
+        this.affiliation = affiliation;
+        this.office = office;
+    }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -44,6 +44,6 @@ public class MemberController {
         컨트롤러단에선 오히려 회원 정보를 이용 할 때 Loginable에서 없는 정보가 필요하면
         null로 입력되는 문제가 발생함
         */
-        return ResponseDTO.okWithData(member.getName());
+        return ResponseDTO.okWithData(member.getName());// null
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -2,14 +2,14 @@ package com.final_10aeat.domain.member.controller;
 
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
+import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.service.MemberService;
+import com.final_10aeat.global.security.principal.MemberPrincipal;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,5 +32,18 @@ public class MemberController {
         String token = memberService.login(request);
         response.setHeader("accessToken", token);
         return ResponseDTO.ok();
+    }
+
+    @GetMapping("/test")
+    public ResponseDTO<?> test(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal
+            ){
+        Member member = (Member) memberPrincipal.getMember();
+        /*
+        Security에서 Loginable을 사용해 추상화 하려는 시도를 했으나
+        컨트롤러단에선 오히려 회원 정보를 이용 할 때 Loginable에서 없는 정보가 필요하면
+        null로 입력되는 문제가 발생함
+        */
+        return ResponseDTO.okWithData(member.getName());
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/entity/Member.java
+++ b/src/main/java/com/final_10aeat/domain/member/entity/Member.java
@@ -1,51 +1,52 @@
 package com.final_10aeat.domain.member.entity;
 
 import com.final_10aeat.domain.admin.entity.Office;
-import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
+import com.final_10aeat.global.entity.Loginable;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.Set;
-import lombok.*;
 
 @Entity
 @Getter
-@Builder
 @Table(name = "member", indexes = @Index(
-    name = "idx_email_deletedAt", columnList = "email, deletedAt", unique = true
+        name = "idx_email_deletedAt", columnList = "email, deletedAt", unique = true
 ))
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends SoftDeletableBaseTimeEntity {
+public class Member extends Loginable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
-    private String email;
-
-    @Column
-    private String password;
-
     @Column
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private MemberRole role;
-
     @ManyToMany
     @JoinTable(
-        name = "member_building",
-        joinColumns = @JoinColumn(name = "member_id"),
-        inverseJoinColumns = @JoinColumn(name = "building_info_id")
+            name = "member_building",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "building_info_id")
     )
     private Set<BuildingInfo> buildingInfos;
 
     @ManyToMany
     @JoinTable(
-        name = "member_office",
-        joinColumns = @JoinColumn(name = "member_id"),
-        inverseJoinColumns = @JoinColumn(name = "office_id")
+            name = "member_office",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "office_id")
     )
     private Set<Office> offices;
+
+    @Builder
+    private Member(String email, String password, Long id, String name, Set<BuildingInfo> buildingInfos, Set<Office> offices) {
+        super(email, password, MemberRole.OWNER);//현재 프로젝트에는 가정하고 있기 때문에 OWENER로 초기화
+        this.id = id;
+        this.name = name;
+        this.buildingInfos = buildingInfos;
+        this.offices = offices;
+    }
 }

--- a/src/main/java/com/final_10aeat/global/entity/Loginable.java
+++ b/src/main/java/com/final_10aeat/global/entity/Loginable.java
@@ -1,0 +1,31 @@
+package com.final_10aeat.global.entity;
+
+import com.final_10aeat.domain.member.entity.MemberRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class Loginable extends SoftDeletableBaseTimeEntity {
+    @Column(unique = true)
+    protected String email;
+
+    @Column
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    protected Loginable(String email, String password, MemberRole role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    protected Loginable() {
+    }
+}

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.global.security.jwt;
 
 
+import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.global.security.principal.MemberDetailsProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -50,14 +51,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private Authentication getEmailPassword(String token) {
         String email = jwtTokenGenerator.getUserEmail(token);
+        MemberRole role = jwtTokenGenerator.getRole(token);
         if (email != null){
-            UserDetails userDetails = memberDetailsProvider.loadUserByUsername(email);
-            List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
-            return new UsernamePasswordAuthenticationToken(
-                    userDetails,
-                    null,
-                    authorities
-            );
+            if(MemberRole.OWNER == role){
+                UserDetails userDetails = memberDetailsProvider.loadMemberByEmail(email);
+                List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+                return new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        authorities
+                );
+            }
+           if (MemberRole.ADMIN == role){
+               UserDetails userDetails = memberDetailsProvider.loadAdminByEmail(email);
+               List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"));
+               return new UsernamePasswordAuthenticationToken(
+                       userDetails,
+                       null,
+                       authorities
+               );
+           }
         }
         return null;
     }

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
@@ -45,9 +45,9 @@ public class JwtTokenGenerator {
         return claims.get("email", String.class);
     }
 
-    public String getRole(String token) {
+    public MemberRole getRole(String token) {
         Claims claims = extractClaim(token);
-        return claims.get("role", String.class);
+        return Enum.valueOf(MemberRole.class,claims.get("role", String.class));
     }
 
     private Claims extractClaim(String token) {

--- a/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
@@ -9,13 +9,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class MemberDetailsProvider implements UserDetailsService {
+public class MemberDetailsProvider {
 
     private final MemberRepository memberRepository;
 
-    @Override
-    public UserDetails loadUserByUsername(String email) {
+    public UserDetails loadMemberByEmail(String email) {
         return new MemberPrincipal(memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotExistException::new));
+    }
+
+    public UserDetails loadAdminByEmail(String email){
+        return null;// TODO Admin 엔티티 작성 이후 추가
     }
 }

--- a/src/main/java/com/final_10aeat/global/security/principal/MemberPrincipal.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/MemberPrincipal.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.global.security.principal;
 
 import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.global.entity.Loginable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -12,7 +13,7 @@ import java.util.Collection;
 public class MemberPrincipal implements UserDetails {
 
     @Getter
-    private final Member member;
+    private final Loginable member;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
# Pull Request 요약

- Admin, Member를 Loginable로 추상화 합니다
- 결과적으로 컨트롤러에서 사용이 더욱 번거로워지고 한번 더 검색을 해야하기 때문에 좋은 방식은 아닌것같습니다
- 이부분을 고치지 않을경우 문서화 용도로만 작성하고 모두들 확인하신 후에 PR은 merge하지 않고 닫을 예정입니다.
## 변경 사항
- Admin, Member 의 부모로 Loginable을 작성합니다

## 관련 이슈

- #71 
## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-19)
- 작업 종료일: (2024-05-19)

## 유의사항

- 자식클래스에서 Lombok의 생성자를 사용하지 않은 이유 - Lombok에서 리플렉션을 활용해서 어노테이션을 처리하는데 이 때 부모의 super class의 생성자를 호출 할 수 없어 Lombok 자체에서 상속받은 부모의 필드에 접근할 수 없습니다
  - 롬복 개발자가 StackOverFlow에서 직접 답변한 내용

## 참고문헌

- [[how to Call super constructor in Lombok](https://stackoverflow.com/questions/29740078/how-to-call-super-constructor-in-lombok)](https://stackoverflow.com/questions/29740078/how-to-call-super-constructor-in-lombok)
