### PR TITLE
[Fix] 어드민 로그인 정보에 따라 로그인 로직을 나눈다

### DIFF
--- a/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
+++ b/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
@@ -9,7 +9,7 @@ import com.final_10aeat.domain.admin.repository.OfficeRepository;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -63,10 +63,10 @@ public class AdminService {
     @Transactional(readOnly = true)
     public String login(MemberLoginRequestDto request) {
         Admin admin = adminRepository.findByEmail(request.email())
-            .orElseThrow(MemberNotExistException::new);
+            .orElseThrow(UserNotExistException::new);
 
         if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
-            throw new MemberNotExistException();
+            throw new UserNotExistException();
         }
 
         return jwtTokenGenerator.createJwtToken(admin.getEmail(), admin.getRole());

--- a/src/main/java/com/final_10aeat/domain/member/exception/UserNotExistException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/UserNotExistException.java
@@ -3,11 +3,11 @@ package com.final_10aeat.domain.member.exception;
 import com.final_10aeat.global.exception.ApplicationException;
 import com.final_10aeat.global.exception.ErrorCode;
 
-public class MemberNotExistException extends ApplicationException {
+public class UserNotExistException extends ApplicationException {
 
-    private static final ErrorCode ERROR_CODE = ErrorCode.MEMBER_NOT_EXIST;
+    private static final ErrorCode ERROR_CODE = ErrorCode.USER_NOT_EXIST;
 
-    public MemberNotExistException() {
+    public UserNotExistException() {
         super(ERROR_CODE);
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -8,7 +8,7 @@ import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.DisagreementException;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
 import com.final_10aeat.domain.member.exception.MemberMissMatchException;
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
@@ -66,10 +66,10 @@ public class MemberService {
     @Transactional(readOnly = true)
     public String login(MemberLoginRequestDto request) {
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
-                .orElseThrow(MemberNotExistException::new);
+                .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
-            throw new MemberNotExistException();
+            throw new UserNotExistException();
         }
 
         return jwtTokenGenerator.createJwtToken(request.email(),member.getRole());
@@ -77,7 +77,7 @@ public class MemberService {
 
     public void withdraw(MemberWithdrawRequestDto request) {
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
-                .orElseThrow(MemberNotExistException::new);
+                .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
             throw new MemberMissMatchException();

--- a/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
+++ b/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
             .cors(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(
                 auth -> auth
-                    .requestMatchers(HttpMethod.POST, "/members/register", "/members/login",
+                    .requestMatchers(HttpMethod.POST, "/members", "/members/login",
                         "/admin","/admin/login").permitAll()
                     .requestMatchers(HttpMethod.GET, "/health/**").permitAll()
                     .requestMatchers("/docs/**").permitAll()

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -15,8 +15,10 @@ public enum ErrorCode {
     // OFFICE
     OFFICE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 건물입니다."),
 
+    // USER
+    USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
+
     // MEMBER
-    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
     MEMBER_MISMATCH(HttpStatus.CONFLICT, "일치하지 않는 사용자입니다."),

--- a/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/final_10aeat/global/security/jwt/JwtTokenGenerator.java
@@ -4,12 +4,11 @@ package com.final_10aeat.global.security.jwt;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenGenerator {
@@ -22,7 +21,7 @@ public class JwtTokenGenerator {
 
     public JwtTokenGenerator() {
         this.key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
-                Jwts.SIG.HS256.key().build().getAlgorithm());
+            Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
     //TODO: yml 파일이 구체화 된 후에 주입으로 변경
@@ -32,12 +31,12 @@ public class JwtTokenGenerator {
 
     public String createJwtToken(String email, MemberRole memberRole) {
         return Jwts.builder()
-                .claim("email", email)
-                .claim("role",memberRole)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + accessExpiredTimeMills))
-                .signWith(key)
-                .compact();
+            .claim("email", email)
+            .claim("role", memberRole)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + accessExpiredTimeMills))
+            .signWith(key)
+            .compact();
     }
 
     public String getUserEmail(String token) {
@@ -45,16 +44,16 @@ public class JwtTokenGenerator {
         return claims.get("email", String.class);
     }
 
-    public String getRole(String token) {
+    public MemberRole getRole(String token) {
         Claims claims = extractClaim(token);
-        return claims.get("role", String.class);
+        return Enum.valueOf(MemberRole.class, claims.get("role", String.class));
     }
 
     private Claims extractClaim(String token) {
         return Jwts.parser()
-                .verifyWith(key).build()
-                .parseSignedClaims(token)
-                .getPayload();
+            .verifyWith(key).build()
+            .parseSignedClaims(token)
+            .getPayload();
     }
 
 

--- a/src/main/java/com/final_10aeat/global/security/principal/AdminDetailsProvider.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/AdminDetailsProvider.java
@@ -1,0 +1,21 @@
+package com.final_10aeat.global.security.principal;
+
+import com.final_10aeat.domain.admin.repository.AdminRepository;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminDetailsProvider implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        return new AdminPrincipal(adminRepository.findByEmail(email)
+                .orElseThrow(UserNotExistException::new));
+    }
+}

--- a/src/main/java/com/final_10aeat/global/security/principal/AdminPrincipal.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/AdminPrincipal.java
@@ -1,0 +1,50 @@
+package com.final_10aeat.global.security.principal;
+
+import com.final_10aeat.domain.admin.entity.Admin;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class AdminPrincipal implements UserDetails {
+
+    @Getter
+    private final Admin admin;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return admin.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return admin.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
+++ b/src/main/java/com/final_10aeat/global/security/principal/MemberDetailsProvider.java
@@ -1,6 +1,6 @@
 package com.final_10aeat.global.security.principal;
 
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,6 +16,6 @@ public class MemberDetailsProvider implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) {
         return new MemberPrincipal(memberRepository.findByEmailAndDeletedAtIsNull(email)
-                .orElseThrow(MemberNotExistException::new));
+                .orElseThrow(UserNotExistException::new));
     }
 }

--- a/src/test/java/com/final_10aeat/domain/admin/unit/AdminServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/admin/unit/AdminServiceTest.java
@@ -18,7 +18,7 @@ import com.final_10aeat.domain.admin.service.AdminService;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -173,7 +173,7 @@ public class AdminServiceTest {
 
             when(adminRepository.findByEmail(anyString())).thenReturn(Optional.empty());
 
-            assertThrows(MemberNotExistException.class, () -> {
+            assertThrows(UserNotExistException.class, () -> {
                 adminService.login(loginRequestDto);
             });
         }
@@ -193,7 +193,7 @@ public class AdminServiceTest {
             when(adminRepository.findByEmail(anyString())).thenReturn(Optional.of(admin));
             when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
 
-            assertThrows(MemberNotExistException.class, () -> {
+            assertThrows(UserNotExistException.class, () -> {
                 adminService.login(loginRequestDto);
             });
         }

--- a/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.entity.MemberRole;
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.member.service.MemberService;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
@@ -78,7 +78,7 @@ class MemberServiceTest {
                 .willReturn(Optional.empty());
 
             // when & then
-            assertThrows(MemberNotExistException.class,
+            assertThrows(UserNotExistException.class,
                 () -> memberService.login(loginRequest)
             );
         }
@@ -93,7 +93,7 @@ class MemberServiceTest {
                 .willReturn(Boolean.FALSE);
 
             // when & then
-            assertThrows(MemberNotExistException.class,
+            assertThrows(UserNotExistException.class,
                 () -> memberService.login(loginRequest));
         }
     }

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -6,7 +6,7 @@ import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.entity.MemberRole;
 import com.final_10aeat.domain.member.exception.MemberMissMatchException;
-import com.final_10aeat.domain.member.exception.MemberNotExistException;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.member.service.MemberService;
@@ -99,7 +99,7 @@ public class WithdrawServiceTest {
             String wrongEmail = "2222@naver.com";
             MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(wrongEmail, password);
 
-            Assertions.assertThrows(MemberNotExistException.class, () -> memberService.withdraw(memberRequest));
+            Assertions.assertThrows(UserNotExistException.class, () -> memberService.withdraw(memberRequest));
         }
     }
 }


### PR DESCRIPTION
# Pull Request 요약

- 기존 Admin, Member 상관 없이 모두 Member에서 조회하는 문제를 해결했습니다
- Member 와 Admin 공통에서 사용하는 예외의 이름을 변경했습니다
- 경로를 일부 수정했습니다

## 변경 사항

- AdminPrincipal : MemberPrincipal과 별개로 작성
- JwtAuthenticationFilter : 필터에서 role별로 다른 로직을 거칠 수 있도록 수정
- SecurityConfig : 멤버 가입 로직이 permit 되어있지 않아 수정했습니다

## 관련 이슈

- #84 

## 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-21)
- 작업 종료일:(2024-05-21)

## 유의사항
- 컨트롤러에서 Member 사용시
```java
    @GetMapping
    public ResponseDTO<?> test(
        @AuthenticationPrincipal MemberPrincipal principal
    ){
        return ResponseDTO.okWithData(principal.getMember());
    }
```

- 컨트롤러에서 Admin사용시
```java
    @GetMapping
    public ResponseDTO<?> test(
        @AuthenticationPrincipal AdminPrincipal principal
    ){
        return ResponseDTO.okWithData(principal.getAdmin());
    }
```