### PR TITLE
[Feature] 유지보수 게시글의 안건진행상황 등록, 수정을 구현한다.

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/final_10aeat/domain/manager/controller/ManagerController.java
@@ -24,7 +24,7 @@ public class ManagerController {
     @PostMapping
     public ResponseEntity<ResponseDTO<Void>> register(
         @RequestBody @Valid CreateManagerRequestDto request) {
-        Manager manager = managerService.register(request);
+        managerService.register(request);
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 

--- a/src/main/java/com/final_10aeat/domain/repairArticle/controller/ManagerRepairArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/controller/ManagerRepairArticleController.java
@@ -1,8 +1,10 @@
 package com.final_10aeat.domain.repairArticle.controller;
 
+import com.final_10aeat.domain.repairArticle.dto.request.CreateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.CreateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.UpdateRepairArticleRequestDto;
-import com.final_10aeat.domain.repairArticle.service.RepairArticleService;
+import com.final_10aeat.domain.repairArticle.service.ManagerRepairArticleService;
 import com.final_10aeat.global.security.principal.ManagerPrincipal;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.validation.Valid;
@@ -24,14 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/managers/repair/article")
 public class ManagerRepairArticleController {
 
-    private final RepairArticleService repairArticleService;
+    private final ManagerRepairArticleService managerRepairArticleService;
 
     @PostMapping
     public ResponseEntity<ResponseDTO<Void>> createRepairArticle(@RequestBody @Valid
     CreateRepairArticleRequestDto request) {
         ManagerPrincipal principal = (ManagerPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
-        repairArticleService.createRepairArticle(request, principal.getManager().getId());
+        managerRepairArticleService.createRepairArticle(request, principal.getManager().getId());
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 
@@ -40,7 +42,7 @@ public class ManagerRepairArticleController {
         @PathVariable Long repairArticleId) {
         ManagerPrincipal principal = (ManagerPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
-        repairArticleService.deleteRepairArticleById(repairArticleId,
+        managerRepairArticleService.deleteRepairArticleById(repairArticleId,
             principal.getManager().getId());
         return ResponseEntity.ok(ResponseDTO.ok());
     }
@@ -51,8 +53,29 @@ public class ManagerRepairArticleController {
         @RequestBody UpdateRepairArticleRequestDto request) {
         ManagerPrincipal principal = (ManagerPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
-        repairArticleService.updateRepairArticle(repairArticleId, request,
+        managerRepairArticleService.updateRepairArticle(repairArticleId, request,
             principal.getManager().getId());
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    @PostMapping("/progress/{repairArticleId}")
+    public ResponseEntity<ResponseDTO<Void>> createCustomProgress(
+        @PathVariable Long repairArticleId,
+        @RequestBody @Valid CreateCustomProgressRequestDto request) {
+        ManagerPrincipal principal = (ManagerPrincipal) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+        managerRepairArticleService.createCustomProgress(repairArticleId,
+            principal.getManager().getId(), request);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    @PatchMapping("/progress/{progressId}")
+    public ResponseEntity<ResponseDTO<Void>> updateCustomProgress(@PathVariable Long progressId,
+        @RequestBody @Valid UpdateCustomProgressRequestDto request) {
+        ManagerPrincipal principal = (ManagerPrincipal) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+        managerRepairArticleService.updateCustomProgress(progressId, principal.getManager().getId(),
+            request);
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/dto/request/CreateCustomProgressRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/dto/request/CreateCustomProgressRequestDto.java
@@ -1,0 +1,18 @@
+package com.final_10aeat.domain.repairArticle.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record CreateCustomProgressRequestDto(
+
+    @NotNull(message = "시작 일정은 필수 값 입니다.")
+    LocalDateTime startSchedule,
+    LocalDateTime endSchedule,
+    @NotBlank(message = "제목을 입력해주세요.")
+    String title,
+    @NotBlank(message = "내용을 입력해주세요.")
+    String content
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/dto/request/UpdateCustomProgressRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/dto/request/UpdateCustomProgressRequestDto.java
@@ -1,0 +1,13 @@
+package com.final_10aeat.domain.repairArticle.dto.request;
+
+import java.time.LocalDateTime;
+
+public record UpdateCustomProgressRequestDto(
+    LocalDateTime startSchedule,
+    LocalDateTime endSchedule,
+    String title,
+    String content,
+    Boolean inProgress
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/CustomProgress.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/CustomProgress.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -29,18 +30,23 @@ public class CustomProgress {
     private Long id;
 
     @Column
+    @Setter
     private String title;
 
     @Column
+    @Setter
     private String content;
 
     @Column(name = "inprogress")
+    @Setter
     private boolean inProgress;
 
     @Column(name = "schedule_start")
+    @Setter
     private LocalDateTime startSchedule;
 
     @Column(name = "schedule_end")
+    @Setter
     private LocalDateTime endSchedule;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
@@ -80,6 +80,10 @@ public class RepairArticle extends SoftDeletableBaseTimeEntity {
     @OneToMany(mappedBy = "repairArticle", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RepairArticleImage> images;
 
+    @Setter
+    @OneToMany(mappedBy = "repairArticle", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<CustomProgress> customProgressSet;
+
     public void delete(LocalDateTime currentTime) {
         super.delete(currentTime);
     }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/exception/CustomProgressNotFoundException.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/exception/CustomProgressNotFoundException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.repairArticle.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class CustomProgressNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.CUSTOM_PROGRESS_NOT_FOUND;
+
+    public CustomProgressNotFoundException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/repository/CustomProgressRepository.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/repository/CustomProgressRepository.java
@@ -1,0 +1,8 @@
+package com.final_10aeat.domain.repairArticle.repository;
+
+import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomProgressRepository extends JpaRepository<CustomProgress, Long> {
+
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
@@ -3,13 +3,17 @@ package com.final_10aeat.domain.repairArticle.service;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.manager.repository.ManagerRepository;
+import com.final_10aeat.domain.repairArticle.dto.request.CreateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.CreateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.UpdateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticleImage;
 import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
 import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
 import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
+import com.final_10aeat.domain.repairArticle.repository.CustomProgressRepository;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,10 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class RepairArticleService {
+public class ManagerRepairArticleService {
 
     private final RepairArticleRepository repairArticleRepository;
     private final ManagerRepository managerRepository;
+    private final CustomProgressRepository customProgressRepository;
 
     public void createRepairArticle(CreateRepairArticleRequestDto request,
         Long managerId) {
@@ -121,6 +126,50 @@ public class RepairArticleService {
             repairArticle.getImages().clear();
             Set<RepairArticleImage> images = createImageEntities(request.images(), repairArticle);
             repairArticle.getImages().addAll(images);
+        }
+    }
+
+    public void createCustomProgress(Long repairArticleId, Long managerId,
+        CreateCustomProgressRequestDto request) {
+        RepairArticle repairArticle = repairArticleRepository.findById(repairArticleId)
+            .orElseThrow(ArticleNotFoundException::new);
+
+        if (!repairArticle.getManager().getId().equals(managerId)) {
+            throw new UnauthorizedAccessException();
+        }
+
+        CustomProgress customProgress = CustomProgress.builder()
+            .title(request.title())
+            .content(request.content())
+            .startSchedule(request.startSchedule())
+            .endSchedule(request.endSchedule())
+            .inProgress(false)
+            .repairArticle(repairArticle)
+            .build();
+
+        customProgressRepository.save(customProgress);
+    }
+
+    public void updateCustomProgress(Long progressId, Long managerId,
+        UpdateCustomProgressRequestDto request) {
+        CustomProgress customProgress = customProgressRepository.findById(progressId)
+            .orElseThrow(() -> new RuntimeException("CustomProgress not found"));
+
+        RepairArticle repairArticle = customProgress.getRepairArticle();
+
+        verifyManager(repairArticle, managerId);
+
+        if (request.startSchedule() != null) {
+            customProgress.setStartSchedule(request.startSchedule());
+        }
+        if (request.endSchedule() != null) {
+            customProgress.setEndSchedule(request.endSchedule());
+        }
+        if (request.title() != null) {
+            customProgress.setTitle(request.title());
+        }
+        if (request.content() != null) {
+            customProgress.setContent(request.content());
         }
     }
 }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
@@ -12,6 +12,7 @@ import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticleImage;
 import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
 import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
+import com.final_10aeat.domain.repairArticle.exception.CustomProgressNotFoundException;
 import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
 import com.final_10aeat.domain.repairArticle.repository.CustomProgressRepository;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
@@ -153,10 +154,9 @@ public class ManagerRepairArticleService {
     public void updateCustomProgress(Long progressId, Long managerId,
         UpdateCustomProgressRequestDto request) {
         CustomProgress customProgress = customProgressRepository.findById(progressId)
-            .orElseThrow(() -> new RuntimeException("CustomProgress not found"));
+            .orElseThrow(CustomProgressNotFoundException::new);
 
         RepairArticle repairArticle = customProgress.getRepairArticle();
-
         verifyManager(repairArticle, managerId);
 
         if (request.startSchedule() != null) {
@@ -171,5 +171,16 @@ public class ManagerRepairArticleService {
         if (request.content() != null) {
             customProgress.setContent(request.content());
         }
+        if (request.inProgress() != null) {
+            if (request.inProgress()) {
+                customProgress.getRepairArticle().getCustomProgressSet().forEach(cp -> {
+                    if (!cp.equals(customProgress)) {
+                        cp.setInProgress(false);
+                    }
+                });
+            }
+            customProgress.setInProgress(request.inProgress());
+        }
+        customProgressRepository.save(customProgress);
     }
 }

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -10,11 +10,14 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
 
     // MANAGER
-    MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자입니다"),
+    MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다"),
 
     // ARTICLE
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 게시글입니다."),
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
     ARTICLE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 게시글입니다."),
+
+    // PROGRESS
+    CUSTOM_PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 안건입니다."),
 
     // EMAIL
     EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
@@ -23,7 +26,7 @@ public enum ErrorCode {
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
 
     // OFFICE
-    OFFICE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 건물입니다."),
+    OFFICE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 건물입니다."),
 
     // USER
     USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),


### PR DESCRIPTION
# ⭐️ [Feature] 유지보수 게시글의 안건진행상황 등록, 수정을 구현한다.

## 🛠️ 변경 사항

#### 안건진행상황 등록 
- POST managers/repair/aricles/progress/{repairArticleId}
- inProgress는 false로 자동 등록

#### 안건진행상황 수정
- PATCH managers/repair/aricles/progress/{progressId}
- 요구 사항에서는 inProgress의 상태만 변경되어도 충분하지만, 확장성을 생각해 모든 내용을 변경 가능하도록 구현하였습니다.
- 게시글 내 안건진행상황들 중 하나만이 true값을 가질 수 있도록 구현하였습니다.(inProgress 를 true로 변경시 자동으로 다른 안건들의 inProgress가 false로 변환)

## 💡 관련 이슈

- #96 

## 🛠️ 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-23)
- 작업 종료일: (2024-05-23)

## ❗️ 참고 사항

- 테스트코드 작성은 유지보수 게시글 cud와 함께 작성할 예정


