### PR TITLE
[Test] 유지보수 게시글 관리 로직 REST Docs 문서화 

### DIFF
--- a/src/docs/asciidoc/email/email-api.adoc
+++ b/src/docs/asciidoc/email/email-api.adoc
@@ -5,7 +5,7 @@
 :toc: left
 :toclevels: 2
 
-=== link:../index.html[공통 API]
+=== link:../index.html[시작 페이지로 돌아가기]
 
 [[Email-Send-Verification]]
 == 이메일 인증 코드 전송

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,6 +15,7 @@ endif::[]
 === link:email/email-api.html[이메일 API]
 === link:member/member-api.html[회원가입/로그인 API]
 === link:manager/manager-api.html[관리자 회원가입/로그인 API]
+=== link:repairarticle/repairarticle-api.html[유지보수 게시글 관리 API]
 
 == API Common Response
 

--- a/src/docs/asciidoc/repairarticle/repairarticle-api.adoc
+++ b/src/docs/asciidoc/repairarticle/repairarticle-api.adoc
@@ -1,0 +1,95 @@
+= Repair Article REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+=== link:../index.html[시작 페이지로 돌아가기]
+
+[[Create-Repair-Article]]
+== 유지보수 게시글 생성
+
+유지보수 게시글을 생성하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/create-repair-article/http-request.adoc[]
+include::{snippets}/create-repair-article/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/create-repair-article/http-response.adoc[]
+include::{snippets}/create-repair-article/response-fields.adoc[]
+
+[[Delete-Repair-Article]]
+== 유지보수 게시글 삭제
+
+유지보수 게시글을 삭제하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/delete-repair-article/http-request.adoc[]
+include::{snippets}/delete-repair-article/path-parameters.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/delete-repair-article/http-response.adoc[]
+include::{snippets}/delete-repair-article/response-fields.adoc[]
+
+[[Update-Repair-Article]]
+== 유지보수 게시글 수정
+
+유지보수 게시글을 수정하는 API 입니다.
+
+* PATCH 요청이므로, request body의 일부만 제공되어도 수정이 가능합니다.
+
+=== HttpRequest
+
+include::{snippets}/update-repair-article/http-request.adoc[]
+include::{snippets}/update-repair-article/path-parameters.adoc[]
+include::{snippets}/update-repair-article/request-fields.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/update-repair-article/http-response.adoc[]
+include::{snippets}/update-repair-article/response-fields.adoc[]
+
+[[Create-Custom-Progress]]
+== 유지보수 안건진행사항 생성
+
+유지보수 안건진행사항을 생성하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/create-custom-progress/http-request.adoc[]
+include::{snippets}/create-custom-progress/path-parameters.adoc[]
+include::{snippets}/create-custom-progress/request-fields.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/create-custom-progress/http-response.adoc[]
+include::{snippets}/create-custom-progress/response-fields.adoc[]
+
+[[Update-Custom-Progress]]
+== 유지보수 안건진행사항 수정
+
+유지보수 안건진행사항을 수정하는 API 입니다.
+
+* PATCH 요청이므로, request body의 일부만 제공되어도 수정이 가능합니다.
+* 게시글 내 안건진행사항들 중에서 하나만이 inProgress값을 true로 가질 수 있습니다. (나머지는 false로 자동 업데이트)
+
+=== HttpRequest
+
+include::{snippets}/update-custom-progress/http-request.adoc[]
+include::{snippets}/update-custom-progress/path-parameters.adoc[]
+include::{snippets}/update-custom-progress/request-fields.adoc[]
+
+
+=== HttpResponse
+
+include::{snippets}/update-custom-progress/http-response.adoc[]
+include::{snippets}/update-custom-progress/response-fields.adoc[]

--- a/src/main/java/com/final_10aeat/common/enumclass/Progress.java
+++ b/src/main/java/com/final_10aeat/common/enumclass/Progress.java
@@ -1,5 +1,5 @@
 package com.final_10aeat.common.enumclass;
 
 public enum Progress {
-    COMPLETE, INPROGRESS, PENDDING
+    COMPLETE, INPROGRESS, PENDING
 }

--- a/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
@@ -71,11 +71,11 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
                         .description("COMPLETE, INPROGRESS, PENDING"),
                     fieldWithPath("title").description("유지보수 게시글 제목"),
                     fieldWithPath("content").description("유지보수 게시글 내용"),
-                    fieldWithPath("constructionStart").description("작업 시작 예정일").optional(),
-                    fieldWithPath("constructionEnd").description("작업 종료 예정일").optional(),
-                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름").optional(),
-                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL").optional(),
-                    fieldWithPath("images").description("이미지 URL 목록").optional()
+                    fieldWithPath("constructionStart").description("작업 시작 예정일"),
+                    fieldWithPath("constructionEnd").description("작업 종료 예정일"),
+                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름"),
+                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL"),
+                    fieldWithPath("images").description("이미지 URL 목록")
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")
@@ -135,16 +135,16 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
                 ),
                 requestFields(
                     fieldWithPath("category").description("게시글 카테고리")
-                        .description("INSTALL, REPAIR, REPLACE").optional(),
+                        .description("INSTALL, REPAIR, REPLACE"),
                     fieldWithPath("progress").description("진행 상황")
-                        .description("COMPLETE, INPROGRESS, PENDING").optional(),
-                    fieldWithPath("title").description("유지보수 게시글 제목").optional(),
-                    fieldWithPath("content").description("유지보수 게시글 내용").optional(),
-                    fieldWithPath("constructionStart").description("작업 시작 예정일").optional(),
-                    fieldWithPath("constructionEnd").description("작업 종료 예정일").optional(),
-                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름").optional(),
-                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL").optional(),
-                    fieldWithPath("images").description("이미지 URL 목록").optional()
+                        .description("COMPLETE, INPROGRESS, PENDING"),
+                    fieldWithPath("title").description("유지보수 게시글 제목"),
+                    fieldWithPath("content").description("유지보수 게시글 내용"),
+                    fieldWithPath("constructionStart").description("작업 시작 예정일"),
+                    fieldWithPath("constructionEnd").description("작업 종료 예정일"),
+                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름"),
+                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL"),
+                    fieldWithPath("images").description("이미지 URL 목록")
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")
@@ -177,7 +177,7 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
                 ),
                 requestFields(
                     fieldWithPath("startSchedule").description("안건진행사항 시작 일정"),
-                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정").optional(),
+                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정"),
                     fieldWithPath("title").description("안건진행사항 제목"),
                     fieldWithPath("content").description("안건진행사항 내용")
                 ),
@@ -212,12 +212,12 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
                     parameterWithName("progressId").description("Custom Progress ID")
                 ),
                 requestFields(
-                    fieldWithPath("startSchedule").description("안건진행사항 시작 일정").optional(),
-                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정").optional(),
-                    fieldWithPath("title").description("안건진행사항 제목").optional(),
-                    fieldWithPath("content").description("안건진행사항 내용").optional(),
+                    fieldWithPath("startSchedule").description("안건진행사항 시작 일정"),
+                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정"),
+                    fieldWithPath("title").description("안건진행사항 제목"),
+                    fieldWithPath("content").description("안건진행사항 내용"),
                     fieldWithPath("inProgress").description("진행 중인 안건인지 여부")
-                        .description("진행중 = true/ 종료,진행전 = false").optional()
+                        .description("진행중 = true/ 종료,진행전 = false")
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")

--- a/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
@@ -20,9 +20,11 @@ import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.common.util.manager.WithManager;
 import com.final_10aeat.docs.RestDocsSupport;
 import com.final_10aeat.domain.repairArticle.controller.ManagerRepairArticleController;
+import com.final_10aeat.domain.repairArticle.dto.request.CreateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.CreateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateCustomProgressRequestDto;
 import com.final_10aeat.domain.repairArticle.dto.request.UpdateRepairArticleRequestDto;
-import com.final_10aeat.domain.repairArticle.service.RepairArticleService;
+import com.final_10aeat.domain.repairArticle.service.ManagerRepairArticleService;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +35,7 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
 
     @Override
     public Object initController() {
-        RepairArticleService repairArticleService = mock(RepairArticleService.class);
+        ManagerRepairArticleService repairArticleService = mock(ManagerRepairArticleService.class);
         return new ManagerRepairArticleController(repairArticleService);
     }
 
@@ -143,6 +145,79 @@ public class ManagerRepairArticleDocsTest extends RestDocsSupport {
                     fieldWithPath("repairCompany").description("수리 담당 회사의 이름").optional(),
                     fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL").optional(),
                     fieldWithPath("images").description("이미지 URL 목록").optional()
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("안건진행사항 생성 API 문서화")
+    @Test
+    @WithManager
+    void testCreateCustomProgress() throws Exception {
+        // given
+        CreateCustomProgressRequestDto requestDto = new CreateCustomProgressRequestDto(
+            LocalDateTime.now(),
+            LocalDateTime.now().plusDays(10),
+            "안건진행사항 제목",
+            "안건진행사항 내용"
+        );
+
+        // when & then
+        mockMvc.perform(post("/managers/repair/articles/progress/{repairArticleId}", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("create-custom-progress",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("repairArticleId").description("유지보수 게시글 ID")
+                ),
+                requestFields(
+                    fieldWithPath("startSchedule").description("안건진행사항 시작 일정"),
+                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정").optional(),
+                    fieldWithPath("title").description("안건진행사항 제목"),
+                    fieldWithPath("content").description("안건진행사항 내용")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("안건진행사항 수정 API 문서화")
+    @Test
+    @WithManager
+    void testUpdateCustomProgress() throws Exception {
+        // given
+        UpdateCustomProgressRequestDto requestDto = new UpdateCustomProgressRequestDto(
+            LocalDateTime.now(),
+            LocalDateTime.now().plusDays(15),
+            "안건진행사항 제목 수정",
+            "안건진행사항 내용 수정",
+            true
+        );
+
+        // when & then
+        mockMvc.perform(patch("/managers/repair/articles/progress/{progressId}", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("update-custom-progress",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("progressId").description("Custom Progress ID")
+                ),
+                requestFields(
+                    fieldWithPath("startSchedule").description("안건진행사항 시작 일정").optional(),
+                    fieldWithPath("endSchedule").description("안건진행사항 종료 일정").optional(),
+                    fieldWithPath("title").description("안건진행사항 제목").optional(),
+                    fieldWithPath("content").description("안건진행사항 내용").optional(),
+                    fieldWithPath("inProgress").description("진행 중인 안건인지 여부")
+                        .description("진행중 = true/ 종료,진행전 = false").optional()
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")

--- a/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/repairArticle/docs/ManagerRepairArticleDocsTest.java
@@ -1,0 +1,152 @@
+package com.final_10aeat.domain.repairArticle.docs;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.final_10aeat.common.enumclass.ArticleCategory;
+import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.common.util.manager.WithManager;
+import com.final_10aeat.docs.RestDocsSupport;
+import com.final_10aeat.domain.repairArticle.controller.ManagerRepairArticleController;
+import com.final_10aeat.domain.repairArticle.dto.request.CreateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.service.RepairArticleService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class ManagerRepairArticleDocsTest extends RestDocsSupport {
+
+    @Override
+    public Object initController() {
+        RepairArticleService repairArticleService = mock(RepairArticleService.class);
+        return new ManagerRepairArticleController(repairArticleService);
+    }
+
+    @DisplayName("Repair Article 생성 API 문서화")
+    @Test
+    @WithManager
+    void testCreateRepairArticle() throws Exception {
+        // given
+        CreateRepairArticleRequestDto requestDto = new CreateRepairArticleRequestDto(
+            ArticleCategory.REPAIR,
+            Progress.PENDING,
+            "유지보수 게시글 제목",
+            "내용내용",
+            LocalDateTime.now(),
+            LocalDateTime.now().plusDays(5),
+            "수리 회사 이름",
+            "http://repaircompanywebsite.com",
+            List.of("http://example.com/image1.jpg", "http://example.com/image2.jpg")
+        );
+
+        // when & then
+        mockMvc.perform(post("/managers/repair/articles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("create-repair-article",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("category").description("게시글 카테고리")
+                        .description("INSTALL, REPAIR, REPLACE"),
+                    fieldWithPath("progress").description("진행 상황")
+                        .description("COMPLETE, INPROGRESS, PENDING"),
+                    fieldWithPath("title").description("유지보수 게시글 제목"),
+                    fieldWithPath("content").description("유지보수 게시글 내용"),
+                    fieldWithPath("constructionStart").description("작업 시작 예정일").optional(),
+                    fieldWithPath("constructionEnd").description("작업 종료 예정일").optional(),
+                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름").optional(),
+                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL").optional(),
+                    fieldWithPath("images").description("이미지 URL 목록").optional()
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("Repair Article 삭제 API 문서화")
+    @Test
+    @WithManager
+    void testDeleteRepairArticleById() throws Exception {
+        // given
+
+        // when & then
+        mockMvc.perform(delete("/managers/repair/articles/{repairArticleId}", 1))
+            .andExpect(status().isOk())
+            .andDo(document("delete-repair-article",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("repairArticleId").description("유지보수 게시글 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("Repair Article 수정 API 문서화")
+    @Test
+    @WithManager
+    void testUpdateRepairArticleById() throws Exception {
+        // given
+        UpdateRepairArticleRequestDto requestDto = new UpdateRepairArticleRequestDto(
+            ArticleCategory.REPAIR,
+            Progress.PENDING,
+            "유지보수 게시글 제목 수정",
+            "내용 수정수정",
+            LocalDateTime.now(),
+            LocalDateTime.now().plusDays(5),
+            "수리 회사 이름 수정",
+            "http://updatedrepaircompanywebsite.com",
+            List.of("http://example.com/image3.jpg", "http://example.com/image4.jpg")
+
+        );
+
+        // when & then
+        mockMvc.perform(patch("/managers/repair/articles/{repairArticleId}", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("update-repair-article",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("repairArticleId").description("유지보수 게시글 ID")
+                ),
+                requestFields(
+                    fieldWithPath("category").description("게시글 카테고리")
+                        .description("INSTALL, REPAIR, REPLACE").optional(),
+                    fieldWithPath("progress").description("진행 상황")
+                        .description("COMPLETE, INPROGRESS, PENDING").optional(),
+                    fieldWithPath("title").description("유지보수 게시글 제목").optional(),
+                    fieldWithPath("content").description("유지보수 게시글 내용").optional(),
+                    fieldWithPath("constructionStart").description("작업 시작 예정일").optional(),
+                    fieldWithPath("constructionEnd").description("작업 종료 예정일").optional(),
+                    fieldWithPath("repairCompany").description("수리 담당 회사의 이름").optional(),
+                    fieldWithPath("repairCompanyWebsite").description("수리 회사 웹사이트 URL").optional(),
+                    fieldWithPath("images").description("이미지 URL 목록").optional()
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/repairArticle/unit/ManagerRepairArticleServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/repairArticle/unit/ManagerRepairArticleServiceTest.java
@@ -1,0 +1,380 @@
+package com.final_10aeat.domain.repairArticle.unit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.final_10aeat.common.enumclass.ArticleCategory;
+import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.common.exception.UnauthorizedAccessException;
+import com.final_10aeat.domain.manager.entity.Manager;
+import com.final_10aeat.domain.manager.repository.ManagerRepository;
+import com.final_10aeat.domain.repairArticle.dto.request.CreateCustomProgressRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.CreateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateCustomProgressRequestDto;
+import com.final_10aeat.domain.repairArticle.dto.request.UpdateRepairArticleRequestDto;
+import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
+import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
+import com.final_10aeat.domain.repairArticle.exception.CustomProgressNotFoundException;
+import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
+import com.final_10aeat.domain.repairArticle.repository.CustomProgressRepository;
+import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
+import com.final_10aeat.domain.repairArticle.service.ManagerRepairArticleService;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class ManagerRepairArticleServiceTest {
+
+    @Mock
+    private RepairArticleRepository repairArticleRepository;
+
+    @Mock
+    private ManagerRepository managerRepository;
+
+    @Mock
+    private CustomProgressRepository customProgressRepository;
+
+    @Spy
+    @InjectMocks
+    private ManagerRepairArticleService managerRepairArticleService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private Manager createTestManager() {
+        return Manager.builder()
+            .id(1L)
+            .email("manager@example.com")
+            .password("password")
+            .name("김관리")
+            .phoneNumber("010-1234-5678")
+            .build();
+    }
+
+    private RepairArticle createTestRepairArticle(Manager manager) {
+        return RepairArticle.builder()
+            .id(1L)
+            .category(ArticleCategory.REPAIR)
+            .progress(Progress.INPROGRESS)
+            .title("유지보수 게시글 제목")
+            .content("내용")
+            .startConstruction(LocalDateTime.now())
+            .endConstruction(LocalDateTime.now().plusDays(1))
+            .company("수리 업체 이름")
+            .companyWebsite("http://testcompany.com")
+            .manager(manager)
+            .images(new HashSet<>())
+            .customProgressSet(new HashSet<>())
+            .build();
+    }
+
+    private CustomProgress createTestCustomProgress(RepairArticle repairArticle) {
+        return CustomProgress.builder()
+            .id(1L)
+            .title("안건진행사항 제목")
+            .content("상세 내용")
+            .startSchedule(LocalDateTime.now())
+            .endSchedule(LocalDateTime.now().plusDays(1))
+            .inProgress(false)
+            .repairArticle(repairArticle)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("createRepairArticle()는")
+    class Context_CreateRepairArticle {
+
+        @Test
+        @DisplayName("성공적으로 게시글을 생성한다.")
+        void _willSuccess() {
+            Manager manager = createTestManager();
+            CreateRepairArticleRequestDto requestDto = new CreateRepairArticleRequestDto(
+                ArticleCategory.REPAIR,
+                Progress.INPROGRESS,
+                "유지보수 게시글 제목",
+                "내용내용",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "수리 업체 이름",
+                "http://testcompany.com",
+                Collections.singletonList("http://image.com/image.jpg")
+            );
+
+            when(managerRepository.findById(anyLong())).thenReturn(Optional.of(manager));
+            when(repairArticleRepository.save(any(RepairArticle.class))).thenAnswer(invocation -> {
+                RepairArticle savedArticle = invocation.getArgument(0);
+                savedArticle.setImages(Collections.emptySet());
+                return savedArticle;
+            });
+
+            assertDoesNotThrow(
+                () -> managerRepairArticleService.createRepairArticle(requestDto, 1L));
+            verify(managerRepository).findById(anyLong());
+            verify(repairArticleRepository).save(any(RepairArticle.class));
+        }
+
+        @Test
+        @DisplayName("관리자를 찾을 수 없는 경우 예외를 발생시킨다.")
+        void NotFound_willFail() {
+            CreateRepairArticleRequestDto requestDto = new CreateRepairArticleRequestDto(
+                ArticleCategory.REPAIR,
+                Progress.INPROGRESS,
+                "유지보수 게시글 제목",
+                "내용내용",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "수리 업체 이름",
+                "http://testcompany.com",
+                Collections.singletonList("http://image.com/image.jpg")
+            );
+
+            when(managerRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(ManagerNotFoundException.class,
+                () -> managerRepairArticleService.createRepairArticle(requestDto, 1L));
+            verify(managerRepository).findById(anyLong());
+            verify(repairArticleRepository, never()).save(any(RepairArticle.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRepairArticleById()는")
+    class Context_DeleteRepairArticle {
+
+        @Test
+        @DisplayName("성공적으로 게시글을 삭제한다.")
+        void _willSuccess() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.of(article));
+
+            assertDoesNotThrow(() -> managerRepairArticleService.deleteRepairArticleById(1L, 1L));
+            verify(repairArticleRepository).findById(anyLong());
+            assertTrue(article.isDeleted());
+        }
+
+        @Test
+        @DisplayName("게시글을 찾을 수 없는 경우 예외를 발생시킨다.")
+        void NotFound_willFail() {
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(ArticleNotFoundException.class,
+                () -> managerRepairArticleService.deleteRepairArticleById(1L, 1L));
+            verify(repairArticleRepository).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("권한이 없는 경우 예외를 발생시킨다.")
+        void Unauthorized_willFail() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.of(article));
+
+            assertThrows(UnauthorizedAccessException.class, () -> {
+                managerRepairArticleService.deleteRepairArticleById(1L, 2L);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("updateRepairArticle()는")
+    class Context_UpdateRepairArticle {
+
+        @Test
+        @DisplayName("성공적으로 게시글을 업데이트한다.")
+        void _willSuccess() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            UpdateRepairArticleRequestDto requestDto = new UpdateRepairArticleRequestDto(
+                ArticleCategory.REPAIR,
+                Progress.COMPLETE,
+                "제목 수정",
+                "내용 수정",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2),
+                "수리 업체 수정",
+                "http://updatedcompany.com",
+                Collections.singletonList("http://image.com/new_image.jpg")
+            );
+
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.of(article));
+
+            assertDoesNotThrow(
+                () -> managerRepairArticleService.updateRepairArticle(1L, requestDto, 1L));
+            verify(repairArticleRepository).findById(anyLong());
+            verify(repairArticleRepository).save(any(RepairArticle.class));
+        }
+
+        @Test
+        @DisplayName("게시글을 찾을 수 없는 경우 예외 발생")
+        void NotFound_willFail() {
+            UpdateRepairArticleRequestDto requestDto = new UpdateRepairArticleRequestDto(
+                ArticleCategory.REPAIR,
+                Progress.COMPLETE,
+                "Updated Title",
+                "Updated Content",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2),
+                "Updated Company",
+                "http://updatedcompany.com",
+                Collections.singletonList("http://image.com/new_image.jpg")
+            );
+
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(ArticleNotFoundException.class,
+                () -> managerRepairArticleService.updateRepairArticle(1L, requestDto, 1L));
+            verify(repairArticleRepository).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("삭제된 게시글은 업데이트할 수 없다")
+        void BadRequest_willFail() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            article.delete(LocalDateTime.now());
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.of(article));
+
+            UpdateRepairArticleRequestDto requestDto = new UpdateRepairArticleRequestDto(
+                ArticleCategory.REPAIR,
+                Progress.COMPLETE,
+                "제목 수정",
+                "내용 수정",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2),
+                "수리 업체 수정",
+                "http://updatedcompany.com",
+                Collections.singletonList("http://image.com/new_image.jpg")
+            );
+
+            assertThrows(ArticleAlreadyDeletedException.class,
+                () -> managerRepairArticleService.updateRepairArticle(1L, requestDto, 1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("CustomProgress 생성")
+    class Context_CreateCustomProgress {
+
+        @Test
+        @DisplayName("성공적으로 CustomProgress 생성")
+        void willSuccess() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            CreateCustomProgressRequestDto requestDto = new CreateCustomProgressRequestDto(
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "안건진행사항 제목",
+                "상세 내용"
+            );
+
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.of(article));
+            when(customProgressRepository.save(any(CustomProgress.class))).thenAnswer(
+                invocation -> {
+                    CustomProgress savedProgress = invocation.getArgument(0);
+                    return savedProgress;
+                });
+
+            assertDoesNotThrow(
+                () -> managerRepairArticleService.createCustomProgress(1L, 1L, requestDto));
+            verify(repairArticleRepository).findById(anyLong());
+            verify(customProgressRepository).save(any(CustomProgress.class));
+        }
+
+        @Test
+        @DisplayName("게시글을 찾을 수 없는 경우 예외 발생")
+        void NotFound_willFail() {
+            CreateCustomProgressRequestDto requestDto = new CreateCustomProgressRequestDto(
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "Progress Title",
+                "Progress Content"
+            );
+
+            when(repairArticleRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(ArticleNotFoundException.class,
+                () -> managerRepairArticleService.createCustomProgress(1L, 1L, requestDto));
+            verify(repairArticleRepository).findById(anyLong());
+            verify(customProgressRepository, never()).save(any(CustomProgress.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("CustomProgress 업데이트")
+    class Context_UpdateCustomProgress {
+
+        @Test
+        @DisplayName("성공적으로 CustomProgress 업데이트")
+        void _willSuccess() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            CustomProgress customProgress = createTestCustomProgress(article);
+            UpdateCustomProgressRequestDto requestDto = new UpdateCustomProgressRequestDto(
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "안건진행사항 제목 수정",
+                "내용 수정수정",
+                true
+            );
+            when(customProgressRepository.findById(anyLong())).thenReturn(
+                Optional.of(customProgress));
+
+            assertDoesNotThrow(
+                () -> managerRepairArticleService.updateCustomProgress(1L, 1L, requestDto));
+            verify(customProgressRepository).findById(anyLong());
+            verify(customProgressRepository).save(any(CustomProgress.class));
+        }
+
+        @Test
+        @DisplayName("권한이 없는 경우 예외 발생")
+        void Unauthorized_willFail() {
+            RepairArticle article = createTestRepairArticle(createTestManager());
+            CustomProgress customProgress = createTestCustomProgress(article);
+            UpdateCustomProgressRequestDto requestDto = new UpdateCustomProgressRequestDto(
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "안건진행사항 제목 수정",
+                "내용 수정수정",
+                true
+            );
+
+            when(customProgressRepository.findById(anyLong())).thenReturn(
+                Optional.of(customProgress));
+
+            assertThrows(UnauthorizedAccessException.class,
+                () -> managerRepairArticleService.updateCustomProgress(1L, 2L, requestDto));
+        }
+
+        @Test
+        @DisplayName("CustomProgress를 찾을 수 없는 경우 예외 발생")
+        void NotFound_willFail() {
+            UpdateCustomProgressRequestDto requestDto = new UpdateCustomProgressRequestDto(
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                "안건진행사항 제목 수정",
+                "내용 수정수정",
+                true
+            );
+
+            when(customProgressRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            assertThrows(CustomProgressNotFoundException.class,
+                () -> managerRepairArticleService.updateCustomProgress(1L, 1L, requestDto));
+            verify(customProgressRepository).findById(anyLong());
+        }
+    }
+}


### PR DESCRIPTION
# ⭐️ [Test] 유지보수 게시글 관리 로직 REST Docs 문서화 
- 유지보수 게시글 등록, 수정, 삭제 REST Docs 테스트 코드 작성 및 문서화
- 안건진행사항 등록, 수정 REST Docs 테스트 코드 작성 및 문서화

## 💡 관련 이슈

- #100

## ❗️ 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-23)
- 작업 종료일: (2024-05-23)

## ❗️ 유의사항

- unit 테스트는 다음 pr에 올리겠습니다.


