### PR TITLE
[Refactor] 회원가입시 Member에게 관리자 officeId 자동부여 구현

### DIFF
--- a/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/MemberRegisterRequestDto.java
@@ -19,6 +19,6 @@ public record MemberRegisterRequestDto(
         @NotNull
         MemberRole memberRole,
         @NotNull
-        Boolean isTermAgreed
+        Boolean termAgreed
 ) {
 }

--- a/src/main/java/com/final_10aeat/domain/member/exception/MemberMissMatchException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/MemberMissMatchException.java
@@ -10,4 +10,8 @@ public class MemberMissMatchException extends ApplicationException {
     public MemberMissMatchException() {
         super(ERROR_CODE);
     }
+
+    public MemberMissMatchException(String message) {
+        super(ERROR_CODE, message);
+    }
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.final_10aeat.domain.member.service;
 
+import com.final_10aeat.domain.manager.exception.VerificationCodeExpiredException;
 import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
@@ -11,10 +12,15 @@ import com.final_10aeat.domain.member.exception.MemberMissMatchException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
+import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import java.time.LocalDateTime;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,56 +34,98 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenGenerator jwtTokenGenerator;
     private final BuildingInfoRepository buildingInfoRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public MemberLoginRequestDto register(MemberRegisterRequestDto request) {
+        validateEmail(request.email());
+        ensureTermsAgreed(request.termAgreed());
 
-        if (memberRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
-            throw new EmailDuplicatedException();
-        }
+        Long officeId = getOfficeIdFromRedis(request.email());
+        validateDongHo(request);
 
-        if (!request.isTermAgreed()){
-            throw new DisagreementException();
-        }
-
-        String password = passwordEncoder.encode(request.password());
-
-        BuildingInfo buildingInfo = BuildingInfo.builder()
-                .dong(request.dong())
-                .ho(request.ho())
-                .office(null)
-                .build();
-
-        BuildingInfo savedBuildingInfo = buildingInfoRepository.save(buildingInfo);
-
-        Member member = Member.builder()
-                .email(request.email())
-                .password(password)
-                .name(request.name())
-                .role(request.memberRole())
-                .buildingInfos(Set.of(savedBuildingInfo))
-                .termAgreed(request.isTermAgreed())
-                .build();
-
-        memberRepository.save(member);
+        BuildingInfo savedBuildingInfo = saveBuildingInfo(request, officeId);
+        saveMember(request, officeId, savedBuildingInfo);
 
         return new MemberLoginRequestDto(request.email(), request.password());
+    }
+
+    private void validateEmail(String email) {
+        if (memberRepository.existsByEmailAndDeletedAtIsNull(email)) {
+            throw new EmailDuplicatedException();
+        }
+    }
+
+    private void ensureTermsAgreed(Boolean termAgreed) {
+        if (!termAgreed) {
+            throw new DisagreementException();
+        }
+    }
+
+    private Long getOfficeIdFromRedis(String email) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        String userInfoJson = ops.get(email + ":info");
+        if (userInfoJson == null) {
+            throw new VerificationCodeExpiredException();
+        }
+
+        JsonObject userInfo = new Gson().fromJson(userInfoJson, JsonObject.class);
+        return userInfo.get("officeId").getAsLong();
+    }
+
+    private void validateDongHo(MemberRegisterRequestDto request) {
+        JsonObject userInfo = fetchUserInfoFromRedis(request.email());
+        if (!userInfo.get("dong").getAsString().equals(request.dong()) ||
+            !userInfo.get("ho").getAsString().equals(request.ho())) {
+            throw new MemberMissMatchException("관리자가 입력한 동, 호수와 일치하지 않습니다.");
+        }
+    }
+
+    private BuildingInfo saveBuildingInfo(MemberRegisterRequestDto request, Long officeId) {
+        BuildingInfo buildingInfo = BuildingInfo.builder()
+            .dong(request.dong())
+            .ho(request.ho())
+            .office(new Office(officeId))
+            .build();
+
+        return buildingInfoRepository.save(buildingInfo);
+    }
+
+    private void saveMember(MemberRegisterRequestDto request, Long officeId,
+        BuildingInfo savedBuildingInfo) {
+        String encodedPassword = passwordEncoder.encode(request.password());
+        Member member = Member.builder()
+            .email(request.email())
+            .password(encodedPassword)
+            .name(request.name())
+            .role(request.memberRole())
+            .defaultOffice(officeId)
+            .buildingInfos(Set.of(savedBuildingInfo))
+            .termAgreed(request.termAgreed())
+            .build();
+
+        memberRepository.save(member);
+    }
+
+    private JsonObject fetchUserInfoFromRedis(String email) {
+        String userInfoJson = redisTemplate.opsForValue().get(email + ":info");
+        return new Gson().fromJson(userInfoJson, JsonObject.class);
     }
 
     @Transactional(readOnly = true)
     public String login(MemberLoginRequestDto request) {
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
-                .orElseThrow(UserNotExistException::new);
+            .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
             throw new UserNotExistException();
         }
 
-        return jwtTokenGenerator.createJwtToken(request.email(),member.getRole());
+        return jwtTokenGenerator.createJwtToken(request.email(), member.getRole());
     }
 
     public void withdraw(MemberWithdrawRequestDto request) {
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
-                .orElseThrow(UserNotExistException::new);
+            .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
             throw new MemberMissMatchException();

--- a/src/main/java/com/final_10aeat/domain/office/entity/Office.java
+++ b/src/main/java/com/final_10aeat/domain/office/entity/Office.java
@@ -37,4 +37,8 @@ public class Office {
 
     @Column(name = "map_y")
     private Double mapY;
+
+    public Office(Long id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/entity/RepairArticle.java
@@ -3,6 +3,7 @@ package com.final_10aeat.domain.repairArticle.entity;
 import com.final_10aeat.common.enumclass.ArticleCategory;
 import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.domain.manager.entity.Manager;
+import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -83,6 +84,10 @@ public class RepairArticle extends SoftDeletableBaseTimeEntity {
     @Setter
     @OneToMany(mappedBy = "repairArticle", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<CustomProgress> customProgressSet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "office_id")
+    private Office office;
 
     public void delete(LocalDateTime currentTime) {
         super.delete(currentTime);

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerRepairArticleService.java
@@ -56,6 +56,7 @@ public class ManagerRepairArticleService {
             .company(request.repairCompany())
             .companyWebsite(request.repairCompanyWebsite())
             .manager(manager)
+            .office(manager.getOffice())
             .build();
     }
 

--- a/src/test/java/com/final_10aeat/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/MemberControllerDocsTest.java
@@ -89,12 +89,12 @@ public class MemberControllerDocsTest extends RestDocsSupport {
     void testRegister() throws Exception {
         //given
         MemberRegisterRequestDto registerRequest = new MemberRegisterRequestDto(
-                "test@example.com", "password", "test",
-                "102동", "2212호", MemberRole.TENANT, true
+            "test@example.com", "password", "test",
+            "102동", "2212호", MemberRole.TENANT, true
         );
 
         MemberLoginRequestDto loginRequest = new MemberLoginRequestDto(
-                "test@example.com", "password"
+            "test@example.com", "password"
         );
 
         // when
@@ -103,29 +103,29 @@ public class MemberControllerDocsTest extends RestDocsSupport {
 
         // then
         mockMvc.perform(RestDocumentationRequestBuilders.post("/members")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(registerRequest)))
-                .andExpect(status().isOk())
-                .andDo(document("member-register",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("email").description("회원의 이메일"),
-                                fieldWithPath("password").description("회원의 비밀번호"),
-                                fieldWithPath("name").description("회원의 이름"),
-                                fieldWithPath("dong").description("회원이 소유한 동-호수의 동"),
-                                fieldWithPath("ho").description("회원이 소유한 동-호수의 호수"),
-                                fieldWithPath("memberRole").description("회원의 역할"),
-                                fieldWithPath("isTermAgreed").description("약관 동의 여부")
-                        ),
-                        responseHeaders(
-                                headerWithName("accessToken").description("로그인 정보가 포함된 토큰")
-                        )
-                        ,
-                        responseFields(
-                                fieldWithPath("code").description("응답 상태 코드")
-                        )
-                ));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("member-register",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("회원의 이메일"),
+                    fieldWithPath("password").description("회원의 비밀번호"),
+                    fieldWithPath("name").description("회원의 이름"),
+                    fieldWithPath("dong").description("회원이 소유한 동-호수의 동"),
+                    fieldWithPath("ho").description("회원이 소유한 동-호수의 호수"),
+                    fieldWithPath("memberRole").description("회원의 역할"),
+                    fieldWithPath("termAgreed").description("약관 동의 여부")
+                ),
+                responseHeaders(
+                    headerWithName("accessToken").description("로그인 정보가 포함된 토큰")
+                )
+                ,
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
     }
 
     @DisplayName("회원탈퇴 API 문서화")
@@ -133,26 +133,26 @@ public class MemberControllerDocsTest extends RestDocsSupport {
     void testWithdraw() throws Exception {
         //given
         MemberWithdrawRequestDto withdrawRequest = new MemberWithdrawRequestDto(
-                "test@example.com", "password");
+            "test@example.com", "password");
 
         // when
         memberService.withdraw(withdrawRequest);
 
         // then
         mockMvc.perform(RestDocumentationRequestBuilders.delete("/members")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(withdrawRequest)))
-                .andExpect(status().isOk())
-                .andDo(document("member-withdraw",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("email").description("회원의 이메일"),
-                                fieldWithPath("password").description("회원의 비밀번호")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("응답 상태 코드")
-                        )
-                ));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(withdrawRequest)))
+            .andExpect(status().isOk())
+            .andDo(document("member-withdraw",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email").description("회원의 이메일"),
+                    fieldWithPath("password").description("회원의 비밀번호")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
     }
 }

--- a/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
@@ -85,27 +85,27 @@ public class RegisterServiceTest {
         @Test
         @DisplayName("회원가입에 성공한다.")
         void _willSuccess() {
-            // Arrange
+            // Given
             given(memberRepository.existsByEmailAndDeletedAtIsNull(request.email())).willReturn(
                 false);
 
-            // Act
+            // When
             memberService.register(request);
 
-            // Assert
+            // Then
             verify(memberRepository).save(any(Member.class));
             verify(redisTemplate.opsForValue(), times(2)).get(
                 anyString());
         }
 
         @Test
-        @DisplayName("이메일이 중복된 회원의 가입을 시도하여 실패한다.")
+        @DisplayName("이메일이 중복되어 회원 가입에 실패한다.")
         void _willDuplicatedEmail() {
-            // Arrange
+            // Given
             given(memberRepository.existsByEmailAndDeletedAtIsNull(request.email())).willReturn(
                 true);
 
-            // Assert
+            // When & Then
             Assertions.assertThrows(EmailDuplicatedException.class, () -> {
                 memberService.register(request);
             });
@@ -114,11 +114,11 @@ public class RegisterServiceTest {
         @Test
         @DisplayName("약관에 동의하지 않아 가입에 실패한다.")
         void _willDisagreeTerm() {
-            // Arrange
+            // Given
             MemberRegisterRequestDto disagreeRequest = new MemberRegisterRequestDto(
                 "test@test.com", "password", "spring", "102동", "2212호", MemberRole.TENANT, false);
 
-            // Assert
+            // When & Then
             Assertions.assertThrows(DisagreementException.class, () -> {
                 memberService.register(disagreeRequest);
             });

--- a/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/RegisterServiceTest.java
@@ -1,14 +1,16 @@
 package com.final_10aeat.domain.member.unit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
-import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.exception.DisagreementException;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
@@ -23,50 +25,57 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class RegisterServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
-    @Mock
-    private PasswordEncoder passwordEncoder;
-    @Mock
-    private BuildingInfoRepository buildingInfoRepository;
     @InjectMocks
     private MemberService memberService;
 
-    private final String email = "test@test.com";
-    private final String password = "password";
-    private final String name = "spring";
-    private final String dong = "102동";
-    private final String ho = "2212호";
-    private final MemberRole role = MemberRole.TENANT;
+    @Mock
+    private MemberRepository memberRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
-    private final MemberRegisterRequestDto request = new MemberRegisterRequestDto(email, password,
-        name, dong, ho, role, true);
+    @Mock
+    private BuildingInfoRepository buildingInfoRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final MemberRegisterRequestDto request = new MemberRegisterRequestDto(
+        "test@test.com", "password", "spring", "102동", "2212호", MemberRole.TENANT, true);
+
     private final BuildingInfo buildingInfo = BuildingInfo.builder()
-        .dong(dong)
-        .ho(ho)
+        .dong("102동")
+        .ho("2212호")
         .office(null)
         .build();
+
     private final Member member = Member.builder()
         .id(1L)
-        .email(email)
-        .password(password)
-        .name(name)
-        .role(role)
-        .buildingInfos(Set.of(BuildingInfo.builder()
-            .dong(dong)
-            .ho(ho)
-            .office(null)
-            .build()))
+        .email("test@test.com")
+        .password("encodedPassword")
+        .name("spring")
+        .role(MemberRole.TENANT)
+        .buildingInfos(Set.of(buildingInfo))
         .build();
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(
+            "{\"officeId\":1,\"dong\":\"102동\",\"ho\":\"2212호\"}");
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+        when(buildingInfoRepository.save(any(BuildingInfo.class))).thenReturn(buildingInfo);
+        when(memberRepository.save(any(Member.class))).thenReturn(member);
     }
 
     @Nested
@@ -76,46 +85,43 @@ public class RegisterServiceTest {
         @Test
         @DisplayName("회원가입에 성공한다.")
         void _willSuccess() {
-            //given
-            given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
-            given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
-            given(memberRepository.save(any(Member.class))).willReturn(member);
+            // Arrange
+            given(memberRepository.existsByEmailAndDeletedAtIsNull(request.email())).willReturn(
+                false);
 
-            //when
-            MemberLoginRequestDto loginRequest = memberService.register(request);
+            // Act
+            memberService.register(request);
 
-            //then
-            assertEquals(new MemberLoginRequestDto(email, password), loginRequest);
+            // Assert
+            verify(memberRepository).save(any(Member.class));
+            verify(redisTemplate.opsForValue(), times(2)).get(
+                anyString());
         }
 
         @Test
         @DisplayName("이메일이 중복된 회원의 가입을 시도하여 실패한다.")
         void _willDuplicatedEmail() {
-            //given
-            given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
-            given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
-            given(memberRepository.save(any(Member.class))).willReturn(member);
-            given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(true);
+            // Arrange
+            given(memberRepository.existsByEmailAndDeletedAtIsNull(request.email())).willReturn(
+                true);
 
-            //then
-            Assertions.assertThrows(EmailDuplicatedException.class,
-                () -> memberService.register(request));
+            // Assert
+            Assertions.assertThrows(EmailDuplicatedException.class, () -> {
+                memberService.register(request);
+            });
         }
 
         @Test
         @DisplayName("약관에 동의하지 않아 가입에 실패한다.")
         void _willDisagreeTerm() {
-            //given
-            given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
-            given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
-            given(memberRepository.save(any(Member.class))).willReturn(member);
-            given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(false);
-            MemberRegisterRequestDto disagreeRequest = new MemberRegisterRequestDto(email, password,
-                name, dong, ho, role, false);
+            // Arrange
+            MemberRegisterRequestDto disagreeRequest = new MemberRegisterRequestDto(
+                "test@test.com", "password", "spring", "102동", "2212호", MemberRole.TENANT, false);
 
-            //then
-            Assertions.assertThrows(DisagreementException.class,
-                () -> memberService.register(disagreeRequest));
+            // Assert
+            Assertions.assertThrows(DisagreementException.class, () -> {
+                memberService.register(disagreeRequest);
+            });
         }
     }
 }

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -1,26 +1,33 @@
 package com.final_10aeat.domain.member.unit;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
-import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.exception.MemberMissMatchException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.member.service.MemberService;
-import org.junit.jupiter.api.*;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-import java.util.Set;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 
 public class WithdrawServiceTest {
 
@@ -32,44 +39,51 @@ public class WithdrawServiceTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private BuildingInfoRepository buildingInfoRepository;
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
 
     private final String email = "spring@naver.com";
     private final String password = "spring";
     private final BuildingInfo buildingInfo = BuildingInfo.builder()
-            .dong("102동")
-            .ho("2212호")
-            .office(null)
-            .build();
+        .dong("102동")
+        .ho("2212호")
+        .office(null)
+        .build();
     private final Member member = Member.builder()
-            .id(1L)
-            .email(email)
-            .password(password)
-            .name("spring")
-            .role(MemberRole.TENANT)
-            .buildingInfos(Set.of(BuildingInfo.builder()
-                    .dong("102동")
-                    .ho("2212호")
-                    .office(null)
-                    .build()))
-            .build();
-    private final MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email, password, "spring", "103동", "2212호", MemberRole.TENANT, true);
+        .id(1L)
+        .email(email)
+        .password(password)
+        .name("spring")
+        .role(MemberRole.TENANT)
+        .buildingInfos(Set.of(buildingInfo))
+        .build();
+    private final MemberRegisterRequestDto requestDto = new MemberRegisterRequestDto(email,
+        password, "spring", "102동", "2212호", MemberRole.TENANT, true);
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(email + ":info")).thenReturn(
+            "{\"officeId\":1,\"dong\":\"102동\",\"ho\":\"2212호\"}");
+
         given(buildingInfoRepository.save(any(BuildingInfo.class))).willReturn(buildingInfo);
 
         memberService.register(requestDto);
 
-        given(memberRepository.findByEmailAndDeletedAtIsNull(email)).willReturn(Optional.of(member));
+        given(memberRepository.findByEmailAndDeletedAtIsNull(email)).willReturn(
+            Optional.of(member));
         given(memberRepository.existsByEmailAndDeletedAtIsNull(email)).willReturn(false);
-        given(passwordEncoder.matches(password, member.getPassword())).willReturn(true);
+        when(passwordEncoder.matches(password, member.getPassword())).thenReturn(true);
     }
 
     @Nested
     @DisplayName("withdraw()는 ")
-    class Context_Withdraw{
+    class Context_Withdraw {
+
         @Test
         @DisplayName("회원 탈퇴를 성공한다.")
         void _willSuccess() {
@@ -88,18 +102,22 @@ public class WithdrawServiceTest {
         @DisplayName("비밀번호가 일치하지 않는 사용자의 탈퇴를 시도하여 실패한다.")
         void _willMissMatch() {
             String wrongPassword = "2222";
-            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email, wrongPassword);
+            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email,
+                wrongPassword);
 
-            Assertions.assertThrows(MemberMissMatchException.class, () -> memberService.withdraw(memberRequest));
+            Assertions.assertThrows(MemberMissMatchException.class,
+                () -> memberService.withdraw(memberRequest));
         }
 
         @Test
         @DisplayName("회원 탈퇴하려는 계정이 존재하지 않아 실패한다.")
         void _willNotExist() {
             String wrongEmail = "2222@naver.com";
-            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(wrongEmail, password);
+            MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(wrongEmail,
+                password);
 
-            Assertions.assertThrows(UserNotExistException.class, () -> memberService.withdraw(memberRequest));
+            Assertions.assertThrows(UserNotExistException.class,
+                () -> memberService.withdraw(memberRequest));
         }
     }
 }


### PR DESCRIPTION
# ⭐️ [Refactor] 회원가입시 Member에게 관리자 officeId 자동부여 구현

- 변경 사항에 맞춰 member 회원가입 시 인증번호를 보낸 manager의 officeId를 member의 default office id에 저장하는 로직 추가

## 변경 사항

#### MemberMissMatchException에 메시지 입력 추가
 - MemberMissMatchException에 string message를 받는 메서드 작성

#### 변경된 termAgreed DTO에 적용
 - Member엔터티의 isTermAgreed가 termAgreed로 변경되면서 DTO에도 변경사항 적용 필요
 - isTermAgreed -> termAgreed

#### member회원가입시 redis에서 officeId 꺼내와 자동 저장
 - member회원가입시 redis에서 officeId 꺼내와 자동 저장 로직 추가
 - redis의 dong, ho 와 일치하는지 검증, 예외처리 로직 추가
 - buildingInfo 생성시 redis에 있는 officeId 저장
 
#### RepairArticle에 office id 추가
 - 게시글 조회시 사용자의 건물 id를 가지고 있는 관리자의 게시글만 조회 가능해야함
 - RepairArticle에 office연관관계를 추가하고, 게시글을 작성한 관리자의 office id가 게시글에 넣어지도록 수정
 
## 관련 이슈

- #110

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트


## 작업 기간

- 작업 시작일: (2024-05-27)
- 작업 종료일: (2024-05-27)


