### PR TITLE
[Feat] 댓글 CRUD 기능 구현

### DIFF
--- a/src/docs/asciidoc/comment/comment-api.adoc
+++ b/src/docs/asciidoc/comment/comment-api.adoc
@@ -1,0 +1,73 @@
+= Comment REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+=== link:../index.html[시작 페이지로 돌아가기]
+
+[[Create-Comment]]
+== 댓글 생성
+댓글을 생성하는 API입니다.
+
+* 최상단 댓글일 경우 parentCommentId = null
+
+=== HttpRequest
+
+include::{snippets}/create-comment/http-request.adoc[]
+include::{snippets}/create-comment/path-parameters.adoc[]
+include::{snippets}/create-comment/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/create-comment/http-response.adoc[]
+include::{snippets}/create-comment/response-fields.adoc[]
+
+[[Delete-Comment]]
+== 댓글 삭제
+
+댓글을 삭제하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/delete-comment/http-request.adoc[]
+include::{snippets}/delete-comment/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/delete-comment/http-response.adoc[]
+include::{snippets}/delete-comment/response-fields.adoc[]
+
+[[Update-Comment]]
+== 댓글 수정
+댓글을 수정하는 API입니다.
+
+=== HttpRequest
+
+include::{snippets}/update-comment/http-request.adoc[]
+include::{snippets}/update-comment/path-parameters.adoc[]
+include::{snippets}/update-comment/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/update-comment/http-response.adoc[]
+include::{snippets}/update-comment/response-fields.adoc[]
+
+[[Get-Comment]]
+== 댓글 조회
+
+댓글을 조회하는 API 입니다.
+
+* parentCommentId = null 일 경우 반환하지 않습니다.
+* 관리자 댓글일 경우 isManager = true 로 반환됩니다.
+
+=== HttpRequest
+
+include::{snippets}/get-comments-by-article-id/http-request.adoc[]
+include::{snippets}/get-comments-by-article-id/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/get-comments-by-article-id/http-response.adoc[]
+include::{snippets}/get-comments-by-article-id/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -17,6 +17,7 @@ endif::[]
 === link:manager/manager-api.html[관리자 회원가입/로그인 API]
 === link:repairarticle/repairarticle-api.html[유지보수 게시글 관리 API]
 === link:save/articlesave-api.html[게시글 저장 API]
+=== link:comment/comment-api.html[댓글 API]
 
 == API Common Response
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,7 +14,7 @@ endif::[]
 
 === link:email/email-api.html[이메일 API]
 === link:member/member-api.html[회원가입/로그인 API]
-=== link:manager/manager-api.html[관리자 회원가입/로그인 API]
+=== link:manager/manager-api.html[관리자 회원가입/로그인/조회 API]
 === link:repairarticle/repairarticle-api.html[유지보수 게시글 관리 API]
 === link:save/articlesave-api.html[게시글 저장 API]
 === link:comment/comment-api.html[댓글 API]

--- a/src/main/java/com/final_10aeat/common/exception/UnexpectedPrincipalException.java
+++ b/src/main/java/com/final_10aeat/common/exception/UnexpectedPrincipalException.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.common.exception;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class UnexpectedPrincipalException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.UNEXPECTED_PRINCIPAL;
+
+    public UnexpectedPrincipalException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/common/scheduler/DeleteCommentScheduler.java
+++ b/src/main/java/com/final_10aeat/common/scheduler/DeleteCommentScheduler.java
@@ -1,0 +1,24 @@
+package com.final_10aeat.common.scheduler;
+
+import com.final_10aeat.domain.comment.entity.Comment;
+import com.final_10aeat.domain.comment.repository.CommentRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteCommentScheduler {
+
+    private final CommentRepository commentRepository;
+
+    @Scheduled(cron = "0 0 2 * * ?")
+    public void deleteOldSoftDeletedComments() {
+        LocalDateTime oneYearAgo = LocalDateTime.now().minusYears(1);
+        List<Comment> commentsToDelete = commentRepository.findSoftDeletedBefore(oneYearAgo);
+
+        commentRepository.deleteAll(commentsToDelete);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.comment.controller;
 
 import com.final_10aeat.common.exception.UnexpectedPrincipalException;
 import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
+import com.final_10aeat.domain.comment.dto.request.UpdateCommentRequestDto;
 import com.final_10aeat.domain.comment.dto.request.UserIdAndRole;
 import com.final_10aeat.domain.comment.service.CommentService;
 import com.final_10aeat.global.security.principal.ManagerPrincipal;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +32,16 @@ public class CommentController {
         @RequestBody @Valid CreateCommentRequestDto request) {
         UserIdAndRole userIdAndRole = getCurrentIdAndRole();
         commentService.createComment(repairArticleId, request, userIdAndRole.getId(),
+            userIdAndRole.isManager());
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ResponseDTO<Void>> updateComment(
+        @PathVariable Long commentId,
+        @RequestBody @Valid UpdateCommentRequestDto request) {
+        UserIdAndRole userIdAndRole = getCurrentIdAndRole();
+        commentService.updateComment(commentId, request, userIdAndRole.getId(),
             userIdAndRole.isManager());
         return ResponseEntity.ok(ResponseDTO.ok());
     }

--- a/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
@@ -1,0 +1,46 @@
+package com.final_10aeat.domain.comment.controller;
+
+import com.final_10aeat.common.exception.UnexpectedPrincipalException;
+import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
+import com.final_10aeat.domain.comment.dto.request.UserIdAndRole;
+import com.final_10aeat.domain.comment.service.CommentService;
+import com.final_10aeat.global.security.principal.ManagerPrincipal;
+import com.final_10aeat.global.security.principal.MemberPrincipal;
+import com.final_10aeat.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/repair/articles/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{repairArticleId}")
+    public ResponseEntity<ResponseDTO<Void>> createComment(
+        @PathVariable Long repairArticleId,
+        @RequestBody @Valid CreateCommentRequestDto request) {
+        UserIdAndRole userIdAndRole = getCurrentIdAndRole();
+        commentService.createComment(repairArticleId, request, userIdAndRole.getId(),
+            userIdAndRole.isManager());
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    private UserIdAndRole getCurrentIdAndRole() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof MemberPrincipal) {
+            return new UserIdAndRole(((MemberPrincipal) principal).getMember().getId(), false);
+        } else if (principal instanceof ManagerPrincipal) {
+            return new UserIdAndRole(((ManagerPrincipal) principal).getManager().getId(), true);
+        }
+        throw new UnexpectedPrincipalException();
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
@@ -35,7 +35,7 @@ public class CommentController {
         @PathVariable Long repairArticleId,
         @RequestBody @Valid CreateCommentRequestDto request) {
         UserIdAndRole userIdAndRole = getCurrentIdAndRole();
-        commentService.createComment(repairArticleId, request, userIdAndRole.getId(),
+        commentService.createComment(repairArticleId, request, userIdAndRole.id(),
             userIdAndRole.isManager());
         return ResponseEntity.ok(ResponseDTO.ok());
     }
@@ -45,7 +45,7 @@ public class CommentController {
         @PathVariable Long commentId,
         @RequestBody @Valid UpdateCommentRequestDto request) {
         UserIdAndRole userIdAndRole = getCurrentIdAndRole();
-        commentService.updateComment(commentId, request, userIdAndRole.getId(),
+        commentService.updateComment(commentId, request, userIdAndRole.id(),
             userIdAndRole.isManager());
         return ResponseEntity.ok(ResponseDTO.ok());
     }
@@ -64,7 +64,7 @@ public class CommentController {
     public ResponseEntity<ResponseDTO<Void>> deleteComment(
         @PathVariable Long commentId) {
         UserIdAndRole userIdAndRole = getCurrentIdAndRole();
-        commentService.deleteComment(commentId, userIdAndRole.getId(), userIdAndRole.isManager());
+        commentService.deleteComment(commentId, userIdAndRole.id(), userIdAndRole.isManager());
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 

--- a/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,5 +55,13 @@ public class CommentController {
             return new UserIdAndRole(((ManagerPrincipal) principal).getManager().getId(), true);
         }
         throw new UnexpectedPrincipalException();
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteComment(
+        @PathVariable Long commentId) {
+        UserIdAndRole userIdAndRole = getCurrentIdAndRole();
+        commentService.deleteComment(commentId, userIdAndRole.getId(), userIdAndRole.isManager());
+        return ResponseEntity.ok(ResponseDTO.ok());
     }
 }

--- a/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/final_10aeat/domain/comment/controller/CommentController.java
@@ -4,15 +4,18 @@ import com.final_10aeat.common.exception.UnexpectedPrincipalException;
 import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
 import com.final_10aeat.domain.comment.dto.request.UpdateCommentRequestDto;
 import com.final_10aeat.domain.comment.dto.request.UserIdAndRole;
+import com.final_10aeat.domain.comment.dto.response.CommentResponseDto;
 import com.final_10aeat.domain.comment.service.CommentService;
 import com.final_10aeat.global.security.principal.ManagerPrincipal;
 import com.final_10aeat.global.security.principal.MemberPrincipal;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +66,12 @@ public class CommentController {
         UserIdAndRole userIdAndRole = getCurrentIdAndRole();
         commentService.deleteComment(commentId, userIdAndRole.getId(), userIdAndRole.isManager());
         return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+    @GetMapping("/{repairArticleId}")
+    public ResponseEntity<ResponseDTO<List<CommentResponseDto>>> getCommentsByArticleId(
+        @PathVariable Long repairArticleId) {
+        List<CommentResponseDto> comments = commentService.getCommentsByArticleId(repairArticleId);
+        return ResponseEntity.ok(ResponseDTO.okWithData(comments));
     }
 }

--- a/src/main/java/com/final_10aeat/domain/comment/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/request/CreateCommentRequestDto.java
@@ -1,0 +1,11 @@
+package com.final_10aeat.domain.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCommentRequestDto(
+    Long parentCommentId,
+    @NotBlank
+    String content
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/comment/dto/request/UpdateCommentRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/request/UpdateCommentRequestDto.java
@@ -1,0 +1,10 @@
+package com.final_10aeat.domain.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCommentRequestDto(
+    @NotBlank
+    String content
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/comment/dto/request/UserIdAndRole.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/request/UserIdAndRole.java
@@ -1,0 +1,16 @@
+package com.final_10aeat.domain.comment.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserIdAndRole {
+    private final Long id;
+    private final boolean isManager;
+
+    @Builder
+    public UserIdAndRole(Long id, boolean isManager) {
+        this.id = id;
+        this.isManager = isManager;
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/dto/request/UserIdAndRole.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/request/UserIdAndRole.java
@@ -1,16 +1,8 @@
 package com.final_10aeat.domain.comment.dto.request;
 
-import lombok.Builder;
-import lombok.Getter;
+public record UserIdAndRole(
+    Long id,
+    boolean isManager
+) {
 
-@Getter
-public class UserIdAndRole {
-    private final Long id;
-    private final boolean isManager;
-
-    @Builder
-    public UserIdAndRole(Long id, boolean isManager) {
-        this.id = id;
-        this.isManager = isManager;
-    }
 }

--- a/src/main/java/com/final_10aeat/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.comment.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CommentResponseDto(
+    Long id,
+    String content,
+    LocalDateTime updatedAt,
+    Long parentCommentId,
+    boolean isManager,
+    String writer
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
+++ b/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.final_10aeat.domain.comment.entity;
 
+import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.global.entity.SoftDeletableBaseTimeEntity;
@@ -41,6 +42,11 @@ public class Comment extends SoftDeletableBaseTimeEntity {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id")
+    private Manager manager;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "repair_article_id")
     private RepairArticle repairArticle;
+
 }

--- a/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
+++ b/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,4 +52,7 @@ public class Comment extends SoftDeletableBaseTimeEntity {
     @JoinColumn(name = "repair_article_id")
     private RepairArticle repairArticle;
 
+    public void delete(LocalDateTime currentTime) {
+        super.delete(currentTime);
+    }
 }

--- a/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
+++ b/src/main/java/com/final_10aeat/domain/comment/entity/Comment.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -31,6 +32,7 @@ public class Comment extends SoftDeletableBaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(columnDefinition = "TEXT", name = "content")
     private String content;
 

--- a/src/main/java/com/final_10aeat/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/final_10aeat/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,15 @@
+package com.final_10aeat.domain.comment.exception;
+
+import static com.final_10aeat.global.exception.ErrorCode.COMMENT_NOT_FOUND;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class CommentNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = COMMENT_NOT_FOUND;
+
+    public CommentNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/exception/InvalidCommentDepthException.java
+++ b/src/main/java/com/final_10aeat/domain/comment/exception/InvalidCommentDepthException.java
@@ -1,0 +1,15 @@
+package com.final_10aeat.domain.comment.exception;
+
+import static com.final_10aeat.global.exception.ErrorCode.INVALID_COMMENT_DEPTH;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class InvalidCommentDepthException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = INVALID_COMMENT_DEPTH;
+
+    public InvalidCommentDepthException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/exception/ParentCommentNotFoundException.java
+++ b/src/main/java/com/final_10aeat/domain/comment/exception/ParentCommentNotFoundException.java
@@ -1,0 +1,15 @@
+package com.final_10aeat.domain.comment.exception;
+
+import static com.final_10aeat.global.exception.ErrorCode.PARENT_COMMENT_NOT_FOUND;
+
+import com.final_10aeat.global.exception.ApplicationException;
+import com.final_10aeat.global.exception.ErrorCode;
+
+public class ParentCommentNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = PARENT_COMMENT_NOT_FOUND;
+
+    public ParentCommentNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.final_10aeat.domain.comment.repository;
+
+import com.final_10aeat.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,14 @@
 package com.final_10aeat.domain.comment.repository;
 
 import com.final_10aeat.domain.comment.entity.Comment;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("SELECT c FROM Comment c WHERE c.deletedAt IS NOT NULL AND c.deletedAt < :cutoffDate")
+    List<Comment> findSoftDeletedBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
@@ -11,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment c WHERE c.deletedAt IS NOT NULL AND c.deletedAt < :cutoffDate")
     List<Comment> findSoftDeletedBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
+
+    List<Comment> findByRepairArticleIdAndDeletedAtIsNull(Long repairArticleId);
 }

--- a/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
@@ -17,6 +17,7 @@ import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,6 +79,16 @@ public class CommentService {
         checkAuthorization(comment, userId, isManager);
 
         comment.setContent(request.content());
+        commentRepository.save(comment);
+    }
+
+    public void deleteComment(Long commentId, Long userId, boolean isManager) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(CommentNotFoundException::new);
+
+        checkAuthorization(comment, userId, isManager);
+
+        comment.delete(LocalDateTime.now());
         commentRepository.save(comment);
     }
 

--- a/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.final_10aeat.common.exception.ArticleNotFoundException;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
 import com.final_10aeat.domain.comment.dto.request.UpdateCommentRequestDto;
+import com.final_10aeat.domain.comment.dto.response.CommentResponseDto;
 import com.final_10aeat.domain.comment.entity.Comment;
 import com.final_10aeat.domain.comment.exception.CommentNotFoundException;
 import com.final_10aeat.domain.comment.exception.InvalidCommentDepthException;
@@ -18,6 +19,8 @@ import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,5 +105,22 @@ public class CommentService {
                 throw new UnauthorizedAccessException();
             }
         }
+    }
+
+    public List<CommentResponseDto> getCommentsByArticleId(Long repairArticleId) {
+        List<Comment> comments = commentRepository.findByRepairArticleIdAndDeletedAtIsNull(
+            repairArticleId);
+
+        return comments.stream()
+            .map(comment -> new CommentResponseDto(
+                comment.getId(),
+                comment.getContent(),
+                comment.getUpdatedAt(),
+                comment.getParentComment(),
+                comment.getManager() != null,
+                comment.getManager() != null ? comment.getManager().getName()
+                    : comment.getMember().getName()
+            ))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
@@ -1,0 +1,69 @@
+package com.final_10aeat.domain.comment.service;
+
+import com.final_10aeat.common.exception.ArticleNotFoundException;
+import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
+import com.final_10aeat.domain.comment.entity.Comment;
+import com.final_10aeat.domain.comment.exception.InvalidCommentDepthException;
+import com.final_10aeat.domain.comment.exception.ParentCommentNotFoundException;
+import com.final_10aeat.domain.comment.repository.CommentRepository;
+import com.final_10aeat.domain.manager.entity.Manager;
+import com.final_10aeat.domain.manager.repository.ManagerRepository;
+import com.final_10aeat.domain.member.entity.Member;
+import com.final_10aeat.domain.member.exception.UserNotExistException;
+import com.final_10aeat.domain.member.repository.MemberRepository;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.domain.repairArticle.exception.ManagerNotFoundException;
+import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final RepairArticleRepository repairArticleRepository;
+    private final MemberRepository memberRepository;
+    private final ManagerRepository managerRepository;
+
+    public void createComment(Long repairArticleId, CreateCommentRequestDto request, Long userId,
+        boolean isManager) {
+        RepairArticle repairArticle = repairArticleRepository.findById(repairArticleId)
+            .orElseThrow(ArticleNotFoundException::new);
+
+        Comment.CommentBuilder commentBuilder = Comment.builder()
+            .content(request.content())
+            .repairArticle(repairArticle)
+            .parentComment(null);
+
+        if (isManager) {
+            Manager manager = managerRepository.findById(userId)
+                .orElseThrow(ManagerNotFoundException::new);
+            commentBuilder.manager(manager);
+        } else {
+            Member member = memberRepository.findById(userId)
+                .orElseThrow(UserNotExistException::new);
+            commentBuilder.member(member);
+        }
+
+        Comment parentComment = getParentComment(request.parentCommentId());
+
+        if (parentComment != null && parentComment.getParentComment() != null) {
+            throw new InvalidCommentDepthException();
+        }
+
+        commentBuilder.parentComment(parentComment != null ? parentComment.getId() : null);
+
+        commentRepository.save(commentBuilder.build());
+    }
+
+    private Comment getParentComment(Long parentCommentId) {
+        if (parentCommentId == null) {
+            return null;
+        }
+        return commentRepository.findById(parentCommentId)
+            .orElseThrow(ParentCommentNotFoundException::new);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
@@ -107,6 +107,7 @@ public class CommentService {
         }
     }
 
+    @Transactional(readOnly = true)
     public List<CommentResponseDto> getCommentsByArticleId(Long repairArticleId) {
         List<Comment> comments = commentRepository.findByRepairArticleIdAndDeletedAtIsNull(
             repairArticleId);

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // COMMON
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     UNEXPECTED_PRINCIPAL(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 Principal 타입입니다."),
 
     // MANAGER

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     // COMMENT
     INVALID_COMMENT_DEPTH(HttpStatus.BAD_REQUEST, "대댓글은 1단만 작성할 수 있습니다."),
     PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 댓글입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
 
     // COMMON
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+    UNEXPECTED_PRINCIPAL(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 Principal 타입입니다."),
 
     // MANAGER
     MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다"),
@@ -39,6 +40,10 @@ public enum ErrorCode {
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
     ARTICLE_NOT_LIKED(HttpStatus.BAD_REQUEST, "저장하지 않은 게시글입니다."),
     ARTICLE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 저장한 게시글입니다."),
+
+    // COMMENT
+    INVALID_COMMENT_DEPTH(HttpStatus.BAD_REQUEST, "대댓글은 1단만 작성할 수 있습니다."),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 댓글을 찾을 수 없습니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/test/java/com/final_10aeat/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/comment/docs/CommentControllerDocsTest.java
@@ -1,0 +1,175 @@
+package com.final_10aeat.domain.comment.docs;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.final_10aeat.common.util.member.WithMember;
+import com.final_10aeat.docs.RestDocsSupport;
+import com.final_10aeat.domain.comment.controller.CommentController;
+import com.final_10aeat.domain.comment.dto.request.CreateCommentRequestDto;
+import com.final_10aeat.domain.comment.dto.request.UpdateCommentRequestDto;
+import com.final_10aeat.domain.comment.dto.response.CommentResponseDto;
+import com.final_10aeat.domain.comment.service.CommentService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class CommentControllerDocsTest extends RestDocsSupport {
+
+    private CommentService commentService;
+
+    @Override
+    public Object initController() {
+        commentService = Mockito.mock(CommentService.class);
+        return new CommentController(commentService);
+    }
+
+    @DisplayName("댓글 작성 API 문서화")
+    @Test
+    @WithMember
+    void testCreateComment() throws Exception {
+        // given
+        Long repairArticleId = 1L;
+        CreateCommentRequestDto requestDto = new CreateCommentRequestDto(
+            null, "댓글 내용"
+        );
+
+        // when
+        doNothing().when(commentService).createComment(repairArticleId, requestDto, 1L, false);
+
+        // then
+        mockMvc.perform(post("/repair/articles/comments/{repairArticleId}", repairArticleId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("create-comment",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("repairArticleId").description("댓글을 작성할 게시글 ID")
+                ),
+                requestFields(
+                    fieldWithPath("content").description("댓글 내용"),
+                    fieldWithPath("parentCommentId").optional().description("부모 댓글 ID (대댓글일 경우)")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("댓글 삭제 API 문서화")
+    @Test
+    @WithMember
+    void testDeleteComment() throws Exception {
+        // given
+        Long commentId = 1L;
+
+        // when
+        doNothing().when(commentService).deleteComment(commentId, 1L, false);
+
+        // then
+        mockMvc.perform(delete("/repair/articles/comments/{commentId}", commentId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("delete-comment",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("commentId").description("삭제할 댓글 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("댓글 수정 API 문서화")
+    @Test
+    @WithMember
+    void testUpdateComment() throws Exception {
+        // given
+        Long commentId = 1L;
+        UpdateCommentRequestDto requestDto = new UpdateCommentRequestDto(
+            "수정된 댓글 내용"
+        );
+
+        // when
+        doNothing().when(commentService).updateComment(commentId, requestDto, 1L, false);
+
+        // then
+        mockMvc.perform(patch("/repair/articles/comments/{commentId}", commentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("update-comment",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("commentId").description("수정할 댓글 ID")
+                ),
+                requestFields(
+                    fieldWithPath("content").description("수정된 댓글 내용")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("게시글별 댓글 조회 API 문서화")
+    @Test
+    @WithMember
+    void testGetCommentsByArticleId() throws Exception {
+        // given
+        Long repairArticleId = 1L;
+
+        List<CommentResponseDto> responseDtos = List.of(
+            new CommentResponseDto(1L, "댓글 내용", LocalDateTime.now(), null, false, "사용자1"),
+            new CommentResponseDto(2L, "대댓글 내용", LocalDateTime.now(), 1L, false, "사용자2")
+        );
+
+        // when
+        when(commentService.getCommentsByArticleId(repairArticleId)).thenReturn(responseDtos);
+
+        // then
+        mockMvc.perform(get("/repair/articles/comments/{repairArticleId}", repairArticleId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("get-comments-by-article-id",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("repairArticleId").description("댓글을 조회할 게시글 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드"),
+                    fieldWithPath("data[].id").description("댓글 ID"),
+                    fieldWithPath("data[].content").description("댓글 내용"),
+                    fieldWithPath("data[].updatedAt").description("댓글 수정 시간"),
+                    fieldWithPath("data[].parentCommentId").description("부모 댓글 ID").optional().type(
+                        JsonFieldType.NUMBER),
+                    fieldWithPath("data[].isManager").description("관리자 여부"),
+                    fieldWithPath("data[].writer").description("작성자 이름")
+                )
+            ));
+    }
+}


### PR DESCRIPTION
# ⭐️ [Feat] 댓글 CRUD 기능 구현 

- 댓글 CRUD기능을 구현하였습니다.

## 🛠️ 변경 사항

#### 댓글 생성
- POST /repair/articles/comments/{repairArticleId}

#### 댓글 삭제
- DELETE /repair/articles/comments/{commentId}
- soft delete 된지 일년 이상된 댓글들은 데이터베이스에서 삭제

#### 댓글 수정
- PATCH /repair/articles/comments/{commentId}

#### 댓글 조회
- GET /repair/articles/comments/{repairArticleId}

## 💡 관련 이슈

- #118 

## 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-05-28)
- 작업 종료일: (2024-05-28)

## ❗️ 유의사항

- 알림 기능 구현하면서 변경이 있을 수도 있는 부분이어서 최대한 간단하게 작업했습니다.
- 마찬가지로 변경 사항이 있을 수 있어 unit 테스트는 작성하지 않았습니다.

