### PR TITLE
[Fix] Admin 계정 생성 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/final_10aeat/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/final_10aeat/domain/admin/controller/AdminController.java
@@ -1,11 +1,13 @@
 package com.final_10aeat.domain.admin.controller;
 
+import com.final_10aeat.domain.admin.dto.CreateAdminRequestDto;
 import com.final_10aeat.domain.admin.service.AdminService;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +20,17 @@ public class AdminController {
 
     private final AdminService adminService;
 
-
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Void>> register(
+        @RequestBody @Valid CreateAdminRequestDto request) {
+        adminService.createAndSaveAdmin(request);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
 
     @PostMapping("/login")
     public ResponseDTO<Void> login(
-            HttpServletResponse response,
-            @RequestBody @Valid MemberLoginRequestDto request) {
+        HttpServletResponse response,
+        @RequestBody @Valid LoginRequestDto request) {
         String token = adminService.login(request);
         response.setHeader("accessToken", token);
         return ResponseDTO.ok();

--- a/src/main/java/com/final_10aeat/domain/admin/dto/CreateAdminRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/admin/dto/CreateAdminRequestDto.java
@@ -1,0 +1,14 @@
+package com.final_10aeat.domain.admin.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateAdminRequestDto(
+    @NotBlank(message = "이메일은 필수 값입니다.")
+    @Email
+    String email,
+    @NotBlank(message = "비밀번호는 필수 값입니다.")
+    String password
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
+++ b/src/main/java/com/final_10aeat/domain/admin/entity/Admin.java
@@ -1,5 +1,6 @@
 package com.final_10aeat.domain.admin.entity;
 
+import com.final_10aeat.common.enumclass.MemberRole;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,4 +21,8 @@ public class Admin {
 
     @Column
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
 }

--- a/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
+++ b/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
@@ -5,6 +5,7 @@ import com.final_10aeat.domain.admin.dto.CreateAdminRequestDto;
 import com.final_10aeat.domain.admin.entity.Admin;
 import com.final_10aeat.domain.admin.repository.AdminRepository;
 import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
+import com.final_10aeat.domain.member.exception.PasswordMissMatchException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class AdminService {
             .orElseThrow(UserNotExistException::new);
 
         if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
-            throw new UserNotExistException();
+            throw new PasswordMissMatchException();
         }
         return jwtTokenGenerator.createJwtToken(admin.getEmail(), admin.getRole());
     }

--- a/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
+++ b/src/main/java/com/final_10aeat/domain/admin/service/AdminService.java
@@ -1,12 +1,14 @@
 package com.final_10aeat.domain.admin.service;
 
 import com.final_10aeat.common.enumclass.MemberRole;
+import com.final_10aeat.domain.admin.dto.CreateAdminRequestDto;
 import com.final_10aeat.domain.admin.entity.Admin;
 import com.final_10aeat.domain.admin.repository.AdminRepository;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,17 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
     private final JwtTokenGenerator jwtTokenGenerator;
 
-    public String login(MemberLoginRequestDto request) {
-        Admin admin = adminRepository.findByEmail(request.email())
-                .orElseThrow(UserNotExistException::new);
+    @Transactional
+    public void createAndSaveAdmin(CreateAdminRequestDto request) {
+        Admin admin = Admin.builder()
+            .email(request.email())
+            .password(passwordEncoder.encode(request.password()))
+            .role(MemberRole.ADMIN)
+            .build();
+        adminRepository.save(admin);
+    }
 
-        if (!request.password().equals(admin.getPassword())) {
-            //서버용 계정으로 일단 암호화 X
+    public String login(LoginRequestDto request) {
+        Admin admin = adminRepository.findByEmail(request.email())
+            .orElseThrow(UserNotExistException::new);
+
+        if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
             throw new UserNotExistException();
         }
-
-        return jwtTokenGenerator.createJwtToken(admin.getEmail(), MemberRole.ADMIN);
+        return jwtTokenGenerator.createJwtToken(admin.getEmail(), admin.getRole());
     }
 }

--- a/src/main/java/com/final_10aeat/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/final_10aeat/domain/manager/controller/ManagerController.java
@@ -4,23 +4,18 @@ import com.final_10aeat.domain.manager.dto.request.CreateManagerRequestDto;
 import com.final_10aeat.domain.manager.dto.response.GetManagerResponseDto;
 import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.manager.service.ManagerService;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
-import com.final_10aeat.global.security.principal.ManagerPrincipal;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.nio.file.attribute.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,7 +34,7 @@ public class ManagerController {
     @PostMapping("/login")
     public ResponseDTO<Void> login(
         HttpServletResponse response,
-        @RequestBody @Valid MemberLoginRequestDto request) {
+        @RequestBody @Valid LoginRequestDto request) {
         String token = managerService.login(request);
         response.setHeader("accessToken", token);
         return ResponseDTO.ok();

--- a/src/main/java/com/final_10aeat/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/final_10aeat/domain/manager/service/ManagerService.java
@@ -6,7 +6,7 @@ import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.exception.OfficeNotFoundException;
 import com.final_10aeat.domain.manager.repository.ManagerRepository;
 import com.final_10aeat.domain.office.repository.OfficeRepository;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
@@ -62,7 +62,7 @@ public class ManagerService {
     }
 
     @Transactional(readOnly = true)
-    public String login(MemberLoginRequestDto request) {
+    public String login(LoginRequestDto request) {
         Manager manager = managerRepository.findByEmail(request.email())
             .orElseThrow(UserNotExistException::new);
 

--- a/src/main/java/com/final_10aeat/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/final_10aeat/domain/manager/service/ManagerService.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.manager.service;
 
 import com.final_10aeat.domain.manager.dto.request.CreateManagerRequestDto;
 import com.final_10aeat.domain.manager.entity.Manager;
+import com.final_10aeat.domain.member.exception.PasswordMissMatchException;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.exception.OfficeNotFoundException;
 import com.final_10aeat.domain.manager.repository.ManagerRepository;
@@ -67,7 +68,7 @@ public class ManagerService {
             .orElseThrow(UserNotExistException::new);
 
         if (!passwordEncoder.matches(request.password(), manager.getPassword())) {
-            throw new UserNotExistException();
+            throw new PasswordMissMatchException();
         }
 
         return jwtTokenGenerator.createJwtToken(manager.getEmail(), manager.getRole());

--- a/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.final_10aeat.domain.member.controller;
 
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.service.MemberService;
@@ -26,7 +26,7 @@ public class MemberController {
         HttpServletResponse response,
         @RequestBody @Valid MemberRegisterRequestDto request
     ) {
-        MemberLoginRequestDto loginDto = memberService.register(request);
+        LoginRequestDto loginDto = memberService.register(request);
 
         String token = memberService.login(loginDto);
         response.setHeader("accessToken", token);
@@ -37,7 +37,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseDTO<Void> login(
         HttpServletResponse response,
-        @RequestBody @Valid MemberLoginRequestDto request) {
+        @RequestBody @Valid LoginRequestDto request) {
         String token = memberService.login(request);
         response.setHeader("accessToken", token);
         return ResponseDTO.ok();

--- a/src/main/java/com/final_10aeat/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/request/LoginRequestDto.java
@@ -3,8 +3,7 @@ package com.final_10aeat.domain.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public record MemberLoginRequestDto(
-    // 정책이 확정될 때 까지 이메일 정규식 임시 사용
+public record LoginRequestDto(
     @Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$")
     String email,
     @NotBlank

--- a/src/main/java/com/final_10aeat/domain/member/exception/PasswordMissMatchException.java
+++ b/src/main/java/com/final_10aeat/domain/member/exception/PasswordMissMatchException.java
@@ -3,15 +3,15 @@ package com.final_10aeat.domain.member.exception;
 import com.final_10aeat.global.exception.ApplicationException;
 import com.final_10aeat.global.exception.ErrorCode;
 
-public class MemberMissMatchException extends ApplicationException {
+public class PasswordMissMatchException extends ApplicationException {
 
-    private static final ErrorCode ERROR_CODE = ErrorCode.MEMBER_MISMATCH;
+    private static final ErrorCode ERROR_CODE = ErrorCode.PASSWORD_MISMATCH;
 
-    public MemberMissMatchException() {
+    public PasswordMissMatchException() {
         super(ERROR_CODE);
     }
 
-    public MemberMissMatchException(String message) {
+    public PasswordMissMatchException(String message) {
         super(ERROR_CODE, message);
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.final_10aeat.domain.member.service;
 
 import com.final_10aeat.domain.manager.exception.VerificationCodeExpiredException;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
@@ -36,7 +36,7 @@ public class MemberService {
     private final BuildingInfoRepository buildingInfoRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public MemberLoginRequestDto register(MemberRegisterRequestDto request) {
+    public LoginRequestDto register(MemberRegisterRequestDto request) {
         validateEmail(request.email());
         ensureTermsAgreed(request.termAgreed());
 
@@ -46,7 +46,7 @@ public class MemberService {
         BuildingInfo savedBuildingInfo = saveBuildingInfo(request, officeId);
         saveMember(request, officeId, savedBuildingInfo);
 
-        return new MemberLoginRequestDto(request.email(), request.password());
+        return new LoginRequestDto(request.email(), request.password());
     }
 
     private void validateEmail(String email) {
@@ -112,7 +112,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public String login(MemberLoginRequestDto request) {
+    public String login(LoginRequestDto request) {
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
             .orElseThrow(UserNotExistException::new);
 

--- a/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MemberService.java
@@ -8,7 +8,7 @@ import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.DisagreementException;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
-import com.final_10aeat.domain.member.exception.MemberMissMatchException;
+import com.final_10aeat.domain.member.exception.PasswordMissMatchException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
@@ -76,7 +76,7 @@ public class MemberService {
         JsonObject userInfo = fetchUserInfoFromRedis(request.email());
         if (!userInfo.get("dong").getAsString().equals(request.dong()) ||
             !userInfo.get("ho").getAsString().equals(request.ho())) {
-            throw new MemberMissMatchException("관리자가 입력한 동, 호수와 일치하지 않습니다.");
+            throw new PasswordMissMatchException("관리자가 입력한 동, 호수와 일치하지 않습니다.");
         }
     }
 
@@ -117,7 +117,7 @@ public class MemberService {
             .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
-            throw new UserNotExistException();
+            throw new PasswordMissMatchException();
         }
 
         return jwtTokenGenerator.createJwtToken(request.email(), member.getRole());
@@ -128,7 +128,7 @@ public class MemberService {
             .orElseThrow(UserNotExistException::new);
 
         if (!passwordMatcher(request.password(), member)) {
-            throw new MemberMissMatchException();
+            throw new PasswordMissMatchException();
         }
 
         member.delete(LocalDateTime.now());

--- a/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
+++ b/src/main/java/com/final_10aeat/global/config/SecurityConfig.java
@@ -31,22 +31,23 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(
-                        auth -> auth
-                                .requestMatchers(HttpMethod.POST,"/admin/login").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/members", "/members/login", "/members/email/verification").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/managers", "/managers/login").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/health/**").permitAll()
-                                .requestMatchers("/docs/**").permitAll()
-                                .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .sessionManagement(
-                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .csrf(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .cors(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(
+                auth -> auth
+                    .requestMatchers(HttpMethod.POST, "/admin", "/admin/login").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/members", "/members/login",
+                        "/members/email/verification").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/managers", "/managers/login").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/health/**").permitAll()
+                    .requestMatchers("/docs/**").permitAll()
+                    .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
-                ).build();
+            ).build();
     }
 }

--- a/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
+++ b/src/main/java/com/final_10aeat/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     // MEMBER
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
-    MEMBER_MISMATCH(HttpStatus.CONFLICT, "일치하지 않는 사용자입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 비밀번호가 일치하지 않습니다."),
     DISAGREE_TERM(HttpStatus.CONFLICT, "약관에 동의해야 합니다."),
 
     // ARTICLE

--- a/src/test/java/com/final_10aeat/domain/manager/docs/ManagerControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/manager/docs/ManagerControllerDocsTest.java
@@ -24,7 +24,7 @@ import com.final_10aeat.domain.manager.dto.request.CreateManagerRequestDto;
 import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.manager.repository.ManagerRepository;
 import com.final_10aeat.domain.manager.service.ManagerService;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.repository.OfficeRepository;
 import com.final_10aeat.global.security.jwt.JwtTokenGenerator;
@@ -135,7 +135,7 @@ public class ManagerControllerDocsTest extends RestDocsSupport {
     @Test
     void testLoginManager() throws Exception {
         // Given
-        MemberLoginRequestDto loginRequest = new MemberLoginRequestDto(
+        LoginRequestDto loginRequest = new LoginRequestDto(
             "manager@example.com", "managerPassword"
         );
 

--- a/src/test/java/com/final_10aeat/domain/manager/unit/ManagerServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/manager/unit/ManagerServiceTest.java
@@ -10,12 +10,12 @@ import static org.mockito.Mockito.when;
 
 import com.final_10aeat.domain.manager.dto.request.CreateManagerRequestDto;
 import com.final_10aeat.domain.manager.entity.Manager;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.exception.OfficeNotFoundException;
 import com.final_10aeat.domain.manager.repository.ManagerRepository;
 import com.final_10aeat.domain.office.repository.OfficeRepository;
 import com.final_10aeat.domain.manager.service.ManagerService;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
 import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.exception.EmailDuplicatedException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
@@ -146,7 +146,7 @@ public class ManagerServiceTest {
         @Test
         @DisplayName("성공적으로 로그인을 수행한다.")
         void _willSuccess() {
-            MemberLoginRequestDto loginRequestDto = new MemberLoginRequestDto("manager@example.com",
+            LoginRequestDto loginRequestDto = new LoginRequestDto("manager@example.com",
                 "securePassword");
 
             Manager manager = Manager.builder()
@@ -168,7 +168,7 @@ public class ManagerServiceTest {
         @Test
         @DisplayName("존재하지 않는 이메일로 로그인을 시도하면 실패한다.")
         void NotFound_willFail() {
-            MemberLoginRequestDto loginRequestDto = new MemberLoginRequestDto("manager@example.com",
+            LoginRequestDto loginRequestDto = new LoginRequestDto("manager@example.com",
                 "securePassword");
 
             when(managerRepository.findByEmail(anyString())).thenReturn(Optional.empty());
@@ -181,7 +181,7 @@ public class ManagerServiceTest {
         @Test
         @DisplayName("잘못된 비밀번호로 로그인을 시도하면 실패한다.")
         void NotMatch_willFail() {
-            MemberLoginRequestDto loginRequestDto = new MemberLoginRequestDto("manager@example.com",
+            LoginRequestDto loginRequestDto = new LoginRequestDto("manager@example.com",
                 "securePassword");
 
             Manager manager = Manager.builder()

--- a/src/test/java/com/final_10aeat/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/MemberControllerDocsTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.final_10aeat.docs.RestDocsSupport;
 import com.final_10aeat.domain.member.controller.MemberController;
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.common.enumclass.MemberRole;
@@ -54,7 +54,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
     @Test
     void testLogin() throws Exception {
         //given
-        MemberLoginRequestDto loginRequest = new MemberLoginRequestDto(
+        LoginRequestDto loginRequest = new LoginRequestDto(
             "test@example.com", "password"
         );
 
@@ -93,7 +93,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
             "102동", "2212호", MemberRole.TENANT, true
         );
 
-        MemberLoginRequestDto loginRequest = new MemberLoginRequestDto(
+        LoginRequestDto loginRequest = new LoginRequestDto(
             "test@example.com", "password"
         );
 

--- a/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/MemberServiceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
-import com.final_10aeat.domain.member.dto.request.MemberLoginRequestDto;
+import com.final_10aeat.domain.member.dto.request.LoginRequestDto;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.common.enumclass.MemberRole;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
@@ -34,7 +34,7 @@ class MemberServiceTest {
 
     private final String email = "test@test.com";
     private final String password = "password";
-    private final MemberLoginRequestDto loginRequest = new MemberLoginRequestDto(email, password);
+    private final LoginRequestDto loginRequest = new LoginRequestDto(email, password);
     private final Member member = Member.builder()
         .email(email)
         .password(password)

--- a/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/WithdrawServiceTest.java
@@ -10,7 +10,7 @@ import com.final_10aeat.domain.member.dto.request.MemberRegisterRequestDto;
 import com.final_10aeat.domain.member.dto.request.MemberWithdrawRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
-import com.final_10aeat.domain.member.exception.MemberMissMatchException;
+import com.final_10aeat.domain.member.exception.PasswordMissMatchException;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.BuildingInfoRepository;
 import com.final_10aeat.domain.member.repository.MemberRepository;
@@ -105,7 +105,7 @@ public class WithdrawServiceTest {
             MemberWithdrawRequestDto memberRequest = new MemberWithdrawRequestDto(email,
                 wrongPassword);
 
-            Assertions.assertThrows(MemberMissMatchException.class,
+            Assertions.assertThrows(PasswordMissMatchException.class,
                 () -> memberService.withdraw(memberRequest));
         }
 


### PR DESCRIPTION
# ⭐️ [Fix] Admin 계정 생성 추가 및 리팩토링

- Admin 계정에 memberRole이 누락되어 빌딩 등록 기능이 동작하지 않는 문제 발생
- 해결을 위해 Admin 로직을 전체적으로 리팩토링하였습니다.

## 🛠️ 변경 사항

#### 1. Admin 계정생성 api 추가
- POST /admin
- 현재는 빌딩 등록만을 수행하는 계정이지만, 확장을 위해서는 반드시 비밀번호 인코딩이 필요합니다.

#### 2. Admin 엔터티에 누락된 memberRole 추가

#### 3. Admin 로그인 로직 리팩토링

#### 4. 그 외 Member, Manager 도메인 리팩토링
- 몇 가지 부분을 리팩토링 하였습니다. 자세한 내용은 커밋 설명을 참고해주세요!

## 💡 관련 이슈
- #120

## 개발 유형

- [x] 버그 수정
- [x] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## 작업 기간

- 작업 시작일: (2024-05-29)
- 작업 종료일: (2024-05-29)

