### PR TITLE
[Refactor] 변경된 API명세서에 따라 법정점검 생성 코드 변경

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/CreateManageArticleRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/CreateManageArticleRequestDto.java
@@ -1,8 +1,11 @@
 package com.final_10aeat.domain.manageArticle.dto.request;
 
 import com.final_10aeat.common.enumclass.ManagePeriod;
+import com.final_10aeat.domain.manageArticle.dto.request.validator.ScheduleSizeMustBiggerThanZero;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record CreateManageArticleRequestDto(
     @NotNull
@@ -14,7 +17,9 @@ public record CreateManageArticleRequestDto(
     String legalBasis,
     String target,
     String responsibility,
-    String note
+    String note,
+    @Valid @ScheduleSizeMustBiggerThanZero
+    List<ScheduleRequestDto> schedule
 ) {
 
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/ScheduleRequestDto.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/ScheduleRequestDto.java
@@ -1,0 +1,12 @@
+package com.final_10aeat.domain.manageArticle.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record ScheduleRequestDto(
+    @NotNull(message = "시작 날짜는 반드시 존재해야 합니다.")
+    LocalDateTime scheduleStart,
+    LocalDateTime scheduleEnd
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeMustBiggerThanZero.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeMustBiggerThanZero.java
@@ -1,0 +1,20 @@
+package com.final_10aeat.domain.manageArticle.dto.request.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ScheduleSizeValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+public @interface ScheduleSizeMustBiggerThanZero {
+
+    String message() default "일정은 1개 이상 존재해야 합니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeValidator.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeValidator.java
@@ -8,10 +8,6 @@ public class ScheduleSizeValidator implements
     ConstraintValidator<ScheduleSizeMustBiggerThanZero, List<?>> {
 
     @Override
-    public void initialize(ScheduleSizeMustBiggerThanZero constraintAnnotation) {
-    }
-
-    @Override
     public boolean isValid(List<?> list, ConstraintValidatorContext context) {
         return list != null && !list.isEmpty();
     }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeValidator.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/validator/ScheduleSizeValidator.java
@@ -1,0 +1,18 @@
+package com.final_10aeat.domain.manageArticle.dto.request.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class ScheduleSizeValidator implements
+    ConstraintValidator<ScheduleSizeMustBiggerThanZero, List<?>> {
+
+    @Override
+    public void initialize(ScheduleSizeMustBiggerThanZero constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(List<?> list, ConstraintValidatorContext context) {
+        return list != null && !list.isEmpty();
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
@@ -18,7 +18,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -81,5 +83,14 @@ public class ManageArticle extends SoftDeletableBaseTimeEntity {
 
     public void delete(LocalDateTime currentTime) {
         super.delete(currentTime);
+    }
+
+    public void addSchedules(List<ManageSchedule> newSchedules) {
+        Set<ManageSchedule> uniqueSchedules = new HashSet<>(schedules);
+        for (ManageSchedule newSchedule : newSchedules) {
+            if (!uniqueSchedules.contains(newSchedule)) {
+                schedules.add(newSchedule);
+            }
+        }
     }
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageArticle.java
@@ -18,9 +18,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -86,11 +84,6 @@ public class ManageArticle extends SoftDeletableBaseTimeEntity {
     }
 
     public void addSchedules(List<ManageSchedule> newSchedules) {
-        Set<ManageSchedule> uniqueSchedules = new HashSet<>(schedules);
-        for (ManageSchedule newSchedule : newSchedules) {
-            if (!uniqueSchedules.contains(newSchedule)) {
-                schedules.add(newSchedule);
-            }
-        }
+        schedules.addAll(newSchedules);
     }
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/entity/ManageSchedule.java
@@ -14,12 +14,14 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Builder
+@EqualsAndHashCode
 @Table(name = "manage_schedule")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,11 +31,14 @@ public class ManageSchedule {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "iscomplete")
-    private boolean isComplete;
+    @Column(name = "complete")
+    private boolean complete;
 
-    @Column
-    private LocalDateTime schedule;
+    @Column(name = "schedule_start", nullable = false)
+    private LocalDateTime scheduleStart;
+
+    @Column(name = "schedule_end")
+    private LocalDateTime scheduleEnd;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manage_article_id")

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageScheduleRepository.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.final_10aeat.domain.manageArticle.repository;
+
+import com.final_10aeat.domain.manageArticle.entity.ManageSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManageScheduleRepository extends JpaRepository<ManageSchedule, Long> {
+
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ManagerManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ManagerManageArticleService.java
@@ -5,14 +5,18 @@ import static java.util.Optional.ofNullable;
 import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.manageArticle.dto.request.CreateManageArticleRequestDto;
+import com.final_10aeat.domain.manageArticle.dto.request.ScheduleRequestDto;
 import com.final_10aeat.domain.manageArticle.dto.request.UpdateManageArticleRequestDto;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
+import com.final_10aeat.domain.manageArticle.entity.ManageSchedule;
 import com.final_10aeat.domain.manageArticle.repository.ManageArticleRepository;
+import com.final_10aeat.domain.manageArticle.repository.ManageScheduleRepository;
 import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
 import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,12 +27,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class ManagerManageArticleService {
 
     private final ManageArticleRepository manageArticleRepository;
-
+    private final ManageScheduleRepository manageScheduleRepository;
 
     public void create(CreateManageArticleRequestDto request, Manager manager) {
         ManageArticle article = createArticle(request, manager.getOffice());
 
         manageArticleRepository.save(article);
+
+        List<ManageSchedule> list = request.schedule().stream()
+            .map(this::createSchedule).toList();
     }
 
     public void update(
@@ -87,5 +94,13 @@ public class ManagerManageArticleService {
         }
 
         article.delete(LocalDateTime.now());
+    }
+
+    private ManageSchedule createSchedule(ScheduleRequestDto request) {
+        return ManageSchedule.builder()
+            .complete(false)
+            .scheduleStart(request.scheduleStart())
+            .scheduleEnd(request.scheduleEnd())
+            .build();
     }
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ManagerManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ManagerManageArticleService.java
@@ -10,12 +10,12 @@ import com.final_10aeat.domain.manageArticle.dto.request.UpdateManageArticleRequ
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import com.final_10aeat.domain.manageArticle.entity.ManageSchedule;
 import com.final_10aeat.domain.manageArticle.repository.ManageArticleRepository;
-import com.final_10aeat.domain.manageArticle.repository.ManageScheduleRepository;
 import com.final_10aeat.domain.manager.entity.Manager;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
 import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,15 +27,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ManagerManageArticleService {
 
     private final ManageArticleRepository manageArticleRepository;
-    private final ManageScheduleRepository manageScheduleRepository;
 
     public void create(CreateManageArticleRequestDto request, Manager manager) {
         ManageArticle article = createArticle(request, manager.getOffice());
 
-        manageArticleRepository.save(article);
-
-        List<ManageSchedule> list = request.schedule().stream()
+        List<ManageSchedule> scheduleList = request.schedule().stream()
             .map(this::createSchedule).toList();
+
+        article.addSchedules(scheduleList);
+
+        manageArticleRepository.save(article);
     }
 
     public void update(
@@ -78,6 +79,7 @@ public class ManagerManageArticleService {
             .responsibility(request.responsibility())
             .note(request.note())
             .office(office)
+            .schedules(new ArrayList<>())
             .build();
     }
 

--- a/src/test/java/com/final_10aeat/domain/manageArticle/docs/ManagerManageArticleControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/docs/ManagerManageArticleControllerDocsTest.java
@@ -1,7 +1,7 @@
 package com.final_10aeat.domain.manageArticle.docs;
 
+import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -12,41 +12,28 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.final_10aeat.common.enumclass.ManagePeriod;
 import com.final_10aeat.common.util.manager.WithManager;
 import com.final_10aeat.docs.RestDocsSupport;
 import com.final_10aeat.domain.manageArticle.controller.ManagerManageArticleController;
 import com.final_10aeat.domain.manageArticle.dto.request.CreateManageArticleRequestDto;
+import com.final_10aeat.domain.manageArticle.dto.request.ScheduleRequestDto;
 import com.final_10aeat.domain.manageArticle.dto.request.UpdateManageArticleRequestDto;
 import com.final_10aeat.domain.manageArticle.service.ManagerManageArticleService;
-import org.junit.jupiter.api.BeforeEach;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class ManagerManageArticleControllerDocsTest extends RestDocsSupport {
 
-    private ManagerManageArticleService managerManageArticleService;
-    private ObjectMapper objectMapper;
-
     @Override
     public Object initController() {
-        managerManageArticleService = Mockito.mock(ManagerManageArticleService.class);
-        objectMapper = new ObjectMapper();
+        ManagerManageArticleService managerManageArticleService =
+            mock(ManagerManageArticleService.class);
         return new ManagerManageArticleController(managerManageArticleService);
-    }
-
-    @BeforeEach
-    public void setUp(RestDocumentationContextProvider restDocumentation) {
-        mockMvc = MockMvcBuilders
-            .standaloneSetup(initController())
-            .apply(documentationConfiguration(restDocumentation))
-            .build();
     }
 
     @DisplayName("Manager Article 생성 API 문서화")
@@ -54,6 +41,10 @@ public class ManagerManageArticleControllerDocsTest extends RestDocsSupport {
     @WithManager
     void testCreate() throws Exception {
         // given
+        ScheduleRequestDto schedule1 = new ScheduleRequestDto(
+            LocalDateTime.of(2024, 6, 1, 0, 0),
+            LocalDateTime.of(2024, 6, 14, 0, 0)
+        );
         CreateManageArticleRequestDto request = new CreateManageArticleRequestDto(
             ManagePeriod.WEEK,
             1,
@@ -61,7 +52,8 @@ public class ManagerManageArticleControllerDocsTest extends RestDocsSupport {
             "법적 근거",
             "관리 대상",
             "담당자/수리업체",
-            "비고"
+            "비고",
+            List.of(schedule1)
         );
 
         // when & then
@@ -81,7 +73,11 @@ public class ManagerManageArticleControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("legalBasis").description("법적 근거").optional(),
                     fieldWithPath("target").description("관리 대상").optional(),
                     fieldWithPath("responsibility").description("담당 업체").optional(),
-                    fieldWithPath("note").description("비고").optional()
+                    fieldWithPath("note").description("비고").optional(),
+                    fieldWithPath("schedule[].scheduleStart").description("유지관리 시작 일시.")
+                        .type("LocalDateTime"),
+                    fieldWithPath("schedule[].scheduleEnd").description("유지관리 종료 일시 (선택 사항).")
+                        .type("LocalDateTime").optional()
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")

--- a/src/test/java/com/final_10aeat/domain/manageArticle/unit/ManagerManageArticleServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/unit/ManagerManageArticleServiceTest.java
@@ -1,7 +1,7 @@
 package com.final_10aeat.domain.manageArticle.unit;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -12,6 +12,7 @@ import com.final_10aeat.common.enumclass.ManagePeriod;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.common.util.EntityUtil;
 import com.final_10aeat.domain.manageArticle.dto.request.CreateManageArticleRequestDto;
+import com.final_10aeat.domain.manageArticle.dto.request.ScheduleRequestDto;
 import com.final_10aeat.domain.manageArticle.dto.request.UpdateManageArticleRequestDto;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import com.final_10aeat.domain.manageArticle.repository.ManageArticleRepository;
@@ -21,6 +22,7 @@ import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.repairArticle.exception.ArticleAlreadyDeletedException;
 import com.final_10aeat.domain.repairArticle.exception.ArticleNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,6 +70,11 @@ class ManagerManageArticleServiceTest {
     @DisplayName("create()에 성공한다")
     void create_WillSuccess() {
         // given
+        ScheduleRequestDto schedule1 = new ScheduleRequestDto(
+            LocalDateTime.of(2024, 6, 1, 0, 0),
+            LocalDateTime.of(2024, 6, 14, 0, 0)
+        );
+
         CreateManageArticleRequestDto request = new CreateManageArticleRequestDto(
             ManagePeriod.WEEK,
             1,
@@ -75,7 +82,8 @@ class ManagerManageArticleServiceTest {
             "법적 근거",
             "관리 대상",
             "담당자/수리업체",
-            "비고"
+            "비고",
+            List.of(schedule1)
         );
 
         // when


### PR DESCRIPTION
# Pull Request 요약

- 05/30 회의 내용에 따라 변경된 법정점검 게시글 생성 로직에 대한 코드 수정

## 변경 사항

- 커스텀 Validation - ScheduleSizeMustBiggerThanZero 어노테이션 작성
- CreateManageArticleRequestDto : Validation 어노테이션 추가
- ScheduleRequestDto : 클래스 생성
- ManageArticle : 스케쥴 리스트 추가 코드 작성
- ManageSchedule : 
  - 업데이트 시 동등성 검사에 사용될 EqualsAndHashcode 어노테이션 추가
  - 변경 요구사항에 맞게 필드 수정
- ManagerManageArticleService :
  - create 메소드 일부 수정
  - ScheduleRequestDto -> ManageSchedule 변경 메소드 추가
- ManagerManageArticleServiceTest : given 데이터 변경

## 관련 이슈

- #104 

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [x] 테스트 코드 작성
- [x] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-05-30)
- 작업 종료일: (2024-05-31)
