### PR TITLE
[Feat] 내 댓글 조회, 내 저장 게시물 조회 구현 및 관련 로직 리팩토링

### DIFF
--- a/src/docs/asciidoc/member/mypage-api.adoc
+++ b/src/docs/asciidoc/member/mypage-api.adoc
@@ -67,3 +67,29 @@ include::{snippets}/remove-building-info/path-parameters.adoc[]
 
 include::{snippets}/remove-building-info/http-response.adoc[]
 include::{snippets}/remove-building-info/response-fields.adoc[]
+
+[[Get-My-Comments]]
+== 내 댓글 조회
+사용자의 댓글을 조회하는 API입니다.
+
+=== HttpRequest
+
+include::{snippets}/get-my-comments/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/get-my-comments/http-response.adoc[]
+include::{snippets}/get-my-comments/response-fields.adoc[]
+
+[[Get-My-Saved-Articles]]
+== 내 저장 게시글 조회
+사용자가 저장한 게시글을 조회하는 API입니다.
+
+=== HttpRequest
+
+include::{snippets}/get-my-saved-articles/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/get-my-saved-articles/http-response.adoc[]
+include::{snippets}/get-my-saved-articles/response-fields.adoc[]

--- a/src/main/java/com/final_10aeat/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/comment/dto/response/CommentResponseDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record CommentResponseDto(
     Long id,
     String content,
-    LocalDateTime updatedAt,
+    LocalDateTime createdAt,
     Long parentCommentId,
     boolean isManager,
     String writer

--- a/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/final_10aeat/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.domain.comment.repository;
 
 import com.final_10aeat.domain.comment.entity.Comment;
+import com.final_10aeat.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.repairArticle.id = :repairArticleId AND c.deletedAt IS NULL")
     long countByRepairArticleIdAndDeletedAtIsNull(@Param("repairArticleId") Long repairArticleId);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.member = :member AND c.repairArticle.office.id = :officeId AND c.deletedAt IS NULL")
+    List<Comment> findByMemberAndRepairArticleOfficeId(@Param("member") Member member,
+        @Param("officeId") Long officeId);
 }

--- a/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/final_10aeat/domain/comment/service/CommentService.java
@@ -49,10 +49,16 @@ public class CommentService {
             Manager manager = managerRepository.findById(userId)
                 .orElseThrow(ManagerNotFoundException::new);
             commentBuilder.manager(manager);
+            if (!repairArticle.getOffice().getId().equals(manager.getOffice().getId())) {
+                throw new UnauthorizedAccessException();
+            }
         } else {
             Member member = memberRepository.findById(userId)
                 .orElseThrow(UserNotExistException::new);
             commentBuilder.member(member);
+            if (!repairArticle.getOffice().getId().equals(member.getDefaultOffice())) {
+                throw new UnauthorizedAccessException();
+            }
         }
 
         Comment parentComment = getParentComment(request.parentCommentId());
@@ -116,7 +122,7 @@ public class CommentService {
             .map(comment -> new CommentResponseDto(
                 comment.getId(),
                 comment.getContent(),
-                comment.getUpdatedAt(),
+                comment.getCreatedAt(),
                 comment.getParentComment(),
                 comment.getManager() != null,
                 comment.getManager() != null ? comment.getManager().getName()

--- a/src/main/java/com/final_10aeat/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.member.controller;
 
 import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.dto.response.MyBuildingInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MyCommentsResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyInfoResponseDto;
 import com.final_10aeat.domain.member.service.MyPageService;
 import com.final_10aeat.global.security.principal.MemberPrincipal;
@@ -43,7 +44,8 @@ public class MyPageController {
     }
 
     @PostMapping("/building/units")
-    public ResponseDTO<Void> addBuildingInfo(@RequestBody @Valid BuildingInfoRequestDto requestDto) {
+    public ResponseDTO<Void> addBuildingInfo(
+        @RequestBody @Valid BuildingInfoRequestDto requestDto) {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
         myPageService.addBuildingInfo(principal.getMember(), requestDto);
@@ -56,5 +58,13 @@ public class MyPageController {
             .getAuthentication().getPrincipal();
         myPageService.removeBuildingInfo(principal.getMember(), buildingInfoId);
         return ResponseDTO.ok();
+    }
+
+    @GetMapping("/comments")
+    public ResponseDTO<List<MyCommentsResponseDto>> getMyComments() {
+        MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+        List<MyCommentsResponseDto> comments = myPageService.getMyComments(principal.getMember());
+        return ResponseDTO.okWithData(comments);
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/final_10aeat/domain/member/controller/MyPageController.java
@@ -4,12 +4,14 @@ import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.dto.response.MyBuildingInfoResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyCommentsResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MySaveResponseDto;
 import com.final_10aeat.domain.member.service.MyPageService;
 import com.final_10aeat.global.security.principal.MemberPrincipal;
 import com.final_10aeat.global.util.ResponseDTO;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,42 +31,52 @@ public class MyPageController {
     private final MyPageService myPageService;
 
     @GetMapping("/building/units")
-    public ResponseDTO<List<MyBuildingInfoResponseDto>> getBuildingInfo() {
+    public ResponseEntity<ResponseDTO<List<MyBuildingInfoResponseDto>>> getBuildingInfo() {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
-        return ResponseDTO.okWithData(myPageService.getBuildingInfo(principal.getMember()));
+        return ResponseEntity.ok(
+            ResponseDTO.okWithData(myPageService.getBuildingInfo(principal.getMember())));
     }
 
     @GetMapping("/info")
-    public ResponseDTO<MyInfoResponseDto> getMyInfo() {
+    public ResponseEntity<ResponseDTO<MyInfoResponseDto>> getMyInfo() {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
         MyInfoResponseDto myInfo = myPageService.getMyInfo(principal.getMember());
-        return ResponseDTO.okWithData(myInfo);
+        return ResponseEntity.ok(ResponseDTO.okWithData(myInfo));
     }
 
     @PostMapping("/building/units")
-    public ResponseDTO<Void> addBuildingInfo(
+    public ResponseEntity<ResponseDTO<Void>> addBuildingInfo(
         @RequestBody @Valid BuildingInfoRequestDto requestDto) {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
         myPageService.addBuildingInfo(principal.getMember(), requestDto);
-        return ResponseDTO.ok();
+        return ResponseEntity.ok(ResponseDTO.ok());
     }
 
     @DeleteMapping("/building/units/{buildingInfoId}")
-    public ResponseDTO<Void> removeBuildingInfo(@PathVariable Long buildingInfoId) {
+    public ResponseEntity<ResponseDTO<Void>> removeBuildingInfo(@PathVariable Long buildingInfoId) {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
         myPageService.removeBuildingInfo(principal.getMember(), buildingInfoId);
-        return ResponseDTO.ok();
+        return ResponseEntity.ok(ResponseDTO.ok());
     }
 
     @GetMapping("/comments")
-    public ResponseDTO<List<MyCommentsResponseDto>> getMyComments() {
+    public ResponseEntity<ResponseDTO<List<MyCommentsResponseDto>>> getMyComments() {
         MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
             .getAuthentication().getPrincipal();
         List<MyCommentsResponseDto> comments = myPageService.getMyComments(principal.getMember());
-        return ResponseDTO.okWithData(comments);
+        return ResponseEntity.ok(ResponseDTO.okWithData(comments));
+    }
+
+    @GetMapping("/saved-articles")
+    public ResponseEntity<ResponseDTO<List<MySaveResponseDto>>> getMySavedArticles() {
+        MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+        List<MySaveResponseDto> savedArticles = myPageService.getMySavedArticles(
+            principal.getMember().getId());
+        return ResponseEntity.ok(ResponseDTO.okWithData(savedArticles));
     }
 }

--- a/src/main/java/com/final_10aeat/domain/member/dto/response/MyCommentsResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/response/MyCommentsResponseDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record MyCommentsResponseDto(
     Long articleId,
     String content,
-    LocalDateTime updatedAt,
+    LocalDateTime createdAt,
     String writer
 ) {
 

--- a/src/main/java/com/final_10aeat/domain/member/dto/response/MyCommentsResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/response/MyCommentsResponseDto.java
@@ -1,0 +1,12 @@
+package com.final_10aeat.domain.member.dto.response;
+
+import java.time.LocalDateTime;
+
+public record MyCommentsResponseDto(
+    Long articleId,
+    String content,
+    LocalDateTime updatedAt,
+    String writer
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/member/dto/response/MySaveResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/member/dto/response/MySaveResponseDto.java
@@ -1,0 +1,12 @@
+package com.final_10aeat.domain.member.dto.response;
+
+import java.time.LocalDateTime;
+
+public record MySaveResponseDto (
+    Long ArticleId,
+    String title,
+    LocalDateTime createdAt,
+    String Writer
+){
+
+}

--- a/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
@@ -1,7 +1,9 @@
 package com.final_10aeat.domain.member.service;
 
+import com.final_10aeat.domain.comment.repository.CommentRepository;
 import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.dto.response.MyBuildingInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MyCommentsResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyInfoResponseDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
@@ -31,6 +33,7 @@ public class MyPageService {
     private final MemberRepository memberRepository;
     private final OfficeRepository officeRepository;
     private final BuildingInfoRepository buildingInfoRepository;
+    private final CommentRepository commentRepository;
 
     public List<MyBuildingInfoResponseDto> getBuildingInfo(Member member) {
         Member loadedMember = findMemberByIdWithBuildingInfos(member.getId());
@@ -107,6 +110,19 @@ public class MyPageService {
         buildingInfos.remove(buildingInfoToRemove);
         managedMember.setBuildingInfos(buildingInfos);
         memberRepository.save(managedMember);
+    }
+
+    public List<MyCommentsResponseDto> getMyComments(Member member) {
+        return commentRepository.findByMemberAndRepairArticleOfficeId(member,
+                member.getDefaultOffice())
+            .stream()
+            .map(comment -> new MyCommentsResponseDto(
+                comment.getRepairArticle().getId(),
+                comment.getContent(),
+                comment.getUpdatedAt(),
+                comment.getMember().getName()
+            ))
+            .collect(Collectors.toList());
     }
 
     private Member findMemberById(Long memberId) {

--- a/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.dto.response.MyBuildingInfoResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyCommentsResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MySaveResponseDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.BuildingInfoNotAssociatedException;
@@ -17,6 +18,7 @@ import com.final_10aeat.domain.member.repository.MemberRepository;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.exception.OfficeNotFoundException;
 import com.final_10aeat.domain.office.repository.OfficeRepository;
+import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -34,6 +36,7 @@ public class MyPageService {
     private final OfficeRepository officeRepository;
     private final BuildingInfoRepository buildingInfoRepository;
     private final CommentRepository commentRepository;
+    private final ArticleSaveRepository articleSaveRepository;
 
     public List<MyBuildingInfoResponseDto> getBuildingInfo(Member member) {
         Member loadedMember = findMemberByIdWithBuildingInfos(member.getId());
@@ -68,7 +71,7 @@ public class MyPageService {
         Office office = officeRepository.findById(defaultOfficeId)
             .orElseThrow(OfficeNotFoundException::new);
 
-        Member managedMember = findMemberById(member.getId());
+        Member managedMember = findMemberByIdWithBuildingInfos(member.getId());
 
         Set<BuildingInfo> buildingInfos = managedMember.getBuildingInfos();
         if (buildingInfos.stream().anyMatch(
@@ -93,7 +96,7 @@ public class MyPageService {
 
     @Transactional
     public void removeBuildingInfo(Member member, Long buildingInfoId) {
-        Member managedMember = findMemberById(member.getId());
+        Member managedMember = findMemberByIdWithBuildingInfos(member.getId());
 
         Set<BuildingInfo> buildingInfos = managedMember.getBuildingInfos();
         if (buildingInfos.size() <= 1) {
@@ -125,9 +128,19 @@ public class MyPageService {
             .collect(Collectors.toList());
     }
 
-    private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(UserNotExistException::new);
+    public List<MySaveResponseDto> getMySavedArticles(Long memberId) {
+        Member member = findMemberByIdWithBuildingInfos(memberId);
+        Long defaultOfficeId = member.getDefaultOffice();
+
+        return articleSaveRepository.findByMemberAndOffice(member, defaultOfficeId)
+            .stream()
+            .map(articleSave -> new MySaveResponseDto(
+                articleSave.getRepairArticle().getId(),
+                articleSave.getRepairArticle().getTitle(),
+                articleSave.getRepairArticle().getCreatedAt(),
+                articleSave.getRepairArticle().getManager().getName()
+            ))
+            .collect(Collectors.toList());
     }
 
     private Member findMemberByIdWithBuildingInfos(Long memberId) {

--- a/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
+++ b/src/main/java/com/final_10aeat/domain/member/service/MyPageService.java
@@ -119,7 +119,7 @@ public class MyPageService {
             .map(comment -> new MyCommentsResponseDto(
                 comment.getRepairArticle().getId(),
                 comment.getContent(),
-                comment.getUpdatedAt(),
+                comment.getCreatedAt(),
                 comment.getMember().getName()
             ))
             .collect(Collectors.toList());

--- a/src/main/java/com/final_10aeat/domain/save/repository/ArticleSaveRepository.java
+++ b/src/main/java/com/final_10aeat/domain/save/repository/ArticleSaveRepository.java
@@ -21,4 +21,8 @@ public interface ArticleSaveRepository extends JpaRepository<ArticleSave, Long> 
     @Query("SELECT a.repairArticle.id FROM ArticleSave a WHERE a.member.id = :memberId AND a.repairArticle.id IN :articleIds")
     Set<Long> findSavedArticleIdsByMember(@Param("memberId") Long memberId,
         @Param("articleIds") List<Long> articleIds);
+
+    @Query("SELECT a FROM ArticleSave a WHERE a.member = :member AND a.repairArticle.office.id = :officeId")
+    List<ArticleSave> findByMemberAndOffice(@Param("member") Member member,
+        @Param("officeId") Long officeId);
 }

--- a/src/main/java/com/final_10aeat/domain/save/service/ArticleSaveService.java
+++ b/src/main/java/com/final_10aeat/domain/save/service/ArticleSaveService.java
@@ -1,6 +1,7 @@
 package com.final_10aeat.domain.save.service;
 
 import com.final_10aeat.common.exception.ArticleNotFoundException;
+import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.member.entity.Member;
 import com.final_10aeat.domain.member.exception.UserNotExistException;
 import com.final_10aeat.domain.member.repository.MemberRepository;
@@ -11,6 +12,7 @@ import com.final_10aeat.domain.save.exception.ArticleAlreadyLikedException;
 import com.final_10aeat.domain.save.exception.ArticleNotLikedException;
 import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.websocket.AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,10 @@ public class ArticleSaveService {
     public void saveArticle(Long repairArticleId, Long memberId) {
         RepairArticle repairArticle = getRepairArticle(repairArticleId);
         Member member = getMember(memberId);
+
+        if (!repairArticle.getOffice().getId().equals(member.getDefaultOffice())) {
+            throw new UnauthorizedAccessException();
+        }
 
         if (articleSaveRepository.existsByRepairArticleAndMember(repairArticle, member)) {
             throw new ArticleAlreadyLikedException();

--- a/src/test/java/com/final_10aeat/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/comment/docs/CommentControllerDocsTest.java
@@ -177,7 +177,7 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("code").description("응답 상태 코드"),
                     fieldWithPath("data[].id").description("댓글 ID"),
                     fieldWithPath("data[].content").description("댓글 내용"),
-                    fieldWithPath("data[].updatedAt").description("댓글 수정 시간"),
+                    fieldWithPath("data[].createdAt").description("댓글 생성 시간"),
                     fieldWithPath("data[].parentCommentId").description("부모 댓글 ID").optional().type(
                         JsonFieldType.NUMBER),
                     fieldWithPath("data[].isManager").description("관리자 여부"),

--- a/src/test/java/com/final_10aeat/domain/member/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/docs/MyPageControllerDocsTest.java
@@ -18,8 +18,11 @@ import com.final_10aeat.docs.RestDocsSupport;
 import com.final_10aeat.domain.member.controller.MyPageController;
 import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.dto.response.MyBuildingInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MyCommentsResponseDto;
 import com.final_10aeat.domain.member.dto.response.MyInfoResponseDto;
+import com.final_10aeat.domain.member.dto.response.MySaveResponseDto;
 import com.final_10aeat.domain.member.service.MyPageService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -152,6 +155,56 @@ public class MyPageControllerDocsTest extends RestDocsSupport {
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 상태 코드")
+                )
+            ));
+    }
+
+    @DisplayName("내 저장된 게시글 조회 API 문서화")
+    @Test
+    void testGetMySavedArticles() throws Exception {
+        MySaveResponseDto savedArticle1 = new MySaveResponseDto(1L, "게시글 제목1", LocalDateTime.now(), "김관리");
+        MySaveResponseDto savedArticle2 = new MySaveResponseDto(2L, "게시글 제목2", LocalDateTime.now(), "이관리");
+        List<MySaveResponseDto> savedArticles = List.of(savedArticle1, savedArticle2);
+
+        when(myPageService.getMySavedArticles(Mockito.any())).thenReturn(savedArticles);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/my/saved-articles")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("get-my-saved-articles",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드"),
+                    fieldWithPath("data[].ArticleId").description("게시글 ID"),
+                    fieldWithPath("data[].title").description("게시글 제목"),
+                    fieldWithPath("data[].createdAt").description("생성 일시"),
+                    fieldWithPath("data[].Writer").description("게시글 작성자")
+                )
+            ));
+    }
+
+    @DisplayName("내 게시글 댓글 조회 API 문서화")
+    @Test
+    void testGetMyComments() throws Exception {
+        MyCommentsResponseDto comment1 = new MyCommentsResponseDto(1L, "댓글 내용1", LocalDateTime.now(), "김소유");
+        MyCommentsResponseDto comment2 = new MyCommentsResponseDto(2L, "댓글 내용2", LocalDateTime.now(), "김소유");
+        List<MyCommentsResponseDto> comments = List.of(comment1, comment2);
+
+        when(myPageService.getMyComments(Mockito.any())).thenReturn(comments);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/my/comments")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("get-my-comments",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").description("응답 상태 코드"),
+                    fieldWithPath("data[].articleId").description("관련 게시글 ID"),
+                    fieldWithPath("data[].content").description("댓글 내용"),
+                    fieldWithPath("data[].createdAt").description("댓글 작성 시간"),
+                    fieldWithPath("data[].writer").description("댓글 작성자")
                 )
             ));
     }

--- a/src/test/java/com/final_10aeat/domain/member/unit/MyPageServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/MyPageServiceTest.java
@@ -1,4 +1,4 @@
-package com.final_10aeat.domain.save.unit;
+package com.final_10aeat.domain.member.unit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/final_10aeat/domain/member/unit/MyPageServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/member/unit/MyPageServiceTest.java
@@ -3,10 +3,12 @@ package com.final_10aeat.domain.member.unit;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.final_10aeat.common.enumclass.MemberRole;
+import com.final_10aeat.domain.comment.repository.CommentRepository;
 import com.final_10aeat.domain.member.dto.request.BuildingInfoRequestDto;
 import com.final_10aeat.domain.member.entity.BuildingInfo;
 import com.final_10aeat.domain.member.entity.Member;
@@ -21,6 +23,7 @@ import com.final_10aeat.domain.member.service.MyPageService;
 import com.final_10aeat.domain.office.entity.Office;
 import com.final_10aeat.domain.office.exception.OfficeNotFoundException;
 import com.final_10aeat.domain.office.repository.OfficeRepository;
+import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
 import java.util.HashSet;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +42,10 @@ class MyPageServiceTest {
     private OfficeRepository officeRepository;
     @Mock
     private BuildingInfoRepository buildingInfoRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private ArticleSaveRepository articleSaveRepository;
 
     @InjectMocks
     private MyPageService myPageService;
@@ -139,32 +146,34 @@ class MyPageServiceTest {
         @Test
         @DisplayName("성공적으로 건물 정보를 추가한다.")
         void _willSuccess() {
-            when(officeRepository.findById(anyLong())).thenReturn(Optional.of(office));
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+            doReturn(Optional.of(office)).when(officeRepository).findById(anyLong());
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
 
             assertDoesNotThrow(() -> myPageService.addBuildingInfo(member, buildingInfoRequestDto));
             verify(officeRepository).findById(anyLong());
-            verify(memberRepository).findById(anyLong());
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
         }
 
         @Test
         @DisplayName("중복된 건물 정보를 추가하려는 경우 예외를 발생시킨다.")
         void Conflict_willFail() {
-            BuildingInfo buildingInfo = BuildingInfo.builder()
-                .dong("101동")
-                .ho("202호")
+            BuildingInfo existingBuildingInfo = BuildingInfo.builder()
+                .dong(buildingInfoRequestDto.dong())
+                .ho(buildingInfoRequestDto.ho())
                 .office(office)
                 .build();
 
-            member.getBuildingInfos().add(buildingInfo);
+            member.getBuildingInfos().add(existingBuildingInfo);
 
-            when(officeRepository.findById(anyLong())).thenReturn(Optional.of(office));
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+            doReturn(Optional.of(office)).when(officeRepository).findById(anyLong());
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
 
             assertThrows(DuplicateBuildingInfoException.class,
                 () -> myPageService.addBuildingInfo(member, buildingInfoRequestDto));
             verify(officeRepository).findById(anyLong());
-            verify(memberRepository).findById(anyLong());
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
         }
 
         @Test
@@ -193,23 +202,26 @@ class MyPageServiceTest {
                 .build();
 
             member.getBuildingInfos().add(buildingInfo);
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-            when(buildingInfoRepository.findById(anyLong())).thenReturn(Optional.of(buildingInfo));
 
-            assertDoesNotThrow(() -> myPageService.removeBuildingInfo(member, 2L));
-            verify(memberRepository).findById(anyLong());
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
+            doReturn(Optional.of(buildingInfo)).when(buildingInfoRepository).findById(anyLong());
+
+            assertDoesNotThrow(() -> myPageService.removeBuildingInfo(member, buildingInfoId));
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
             verify(buildingInfoRepository).findById(anyLong());
         }
 
         @Test
         @DisplayName("삭제할 건물 정보가 존재하지 않는 경우 예외를 발생시킨다.")
         void NotFound_willFail() {
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-            when(buildingInfoRepository.findById(anyLong())).thenReturn(Optional.empty());
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
+            doReturn(Optional.empty()).when(buildingInfoRepository).findById(anyLong());
 
             assertThrows(BuildingInfoNotFound.class,
                 () -> myPageService.removeBuildingInfo(member, buildingInfoId));
-            verify(memberRepository).findById(anyLong());
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
             verify(buildingInfoRepository).findById(anyLong());
         }
 
@@ -226,12 +238,12 @@ class MyPageServiceTest {
             member.getBuildingInfos().clear();
             member.getBuildingInfos().add(buildingInfo1);
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-            when(buildingInfoRepository.findById(anyLong())).thenReturn(Optional.of(buildingInfo1));
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
 
             assertThrows(MinBuildingInfoRequiredException.class,
                 () -> myPageService.removeBuildingInfo(member, buildingInfo1.getId()));
-            verify(memberRepository).findById(anyLong());
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
         }
 
         @Test
@@ -244,12 +256,13 @@ class MyPageServiceTest {
                 .office(office)
                 .build();
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-            when(buildingInfoRepository.findById(anyLong())).thenReturn(Optional.of(buildingInfo));
+            doReturn(Optional.of(member)).when(memberRepository)
+                .findMemberByIdWithBuildingInfos(anyLong());
+            doReturn(Optional.of(buildingInfo)).when(buildingInfoRepository).findById(anyLong());
 
             assertThrows(BuildingInfoNotAssociatedException.class,
                 () -> myPageService.removeBuildingInfo(member, buildingInfo.getId()));
-            verify(memberRepository).findById(anyLong());
+            verify(memberRepository).findMemberByIdWithBuildingInfos(anyLong());
             verify(buildingInfoRepository).findById(anyLong());
         }
     }


### PR DESCRIPTION
# ⭐️ [Feat] 내 댓글 조회, 내 저장 게시물 조회 구현 및 관련 로직 리팩토링

- 기획에는 없지만 사용 가능성이 있는 api를 구현하였습니다.
- 구현하면서 comment, save 도메인에 예외 처리 추가 및 리팩토링을 진행하였습니다.

## 🛠️ 변경 사항

### 내 댓글 조회
- GET /my/comments
- 사용자의 현재 defaultOfficeId와 일치하는 게시글의 댓글만 조회합니다.

### 내 저장 게시글 조회
- GET /my/saved-articles
- 사용자의 현재 defaultOfficeId와 일치하는 게시글의 저장만 조회합니다.

### save, comment 도메인 리팩토링
- 기획과 일치하게 comment 조회 응답값 변경
- 사용자의 defaultOfficeId와 일치하는 게시물들만 권한을 가질 수 있도록 예외 추가

## 관련 이슈

- #141

## 📃 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [x] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

## ⏱️ 작업 기간

- 작업 시작일: (2024-06-02)
- 작업 종료일: (2024-06-02)

## 📌 유의사항

- 기획에는 없지만 사용 가능성이 있는 api를 구현하였습니다.


