### PR TITLE
[Refactor] 유지보수 게시글 조회 기능 리팩토링

### DIFF
--- a/src/docs/asciidoc/repairarticle/get-repairarticle-api.adoc
+++ b/src/docs/asciidoc/repairarticle/get-repairarticle-api.adoc
@@ -28,19 +28,34 @@ include::{snippets}/get-repair-article-summary/response-fields.adoc[]
 
 유지보수 게시글을 전체 조회하는 API 입니다.
 
-* 정렬 기준 : isNewArticle -> redDot -> 그 외 게시물 최신순 정렬
-* isNewArticle = true 이면 24시간 내에 생성된 게시물입니다.
-* progress, category 파라미터거 없는 경우 전체 게시물이 조회됩니다.
+* 현재 로그인한 사용자가 관리자냐 소유주냐에 따라 응답값이 달라집니다.
+* 정렬 기준 : redDot = true 인 게시물이 최상단에 노출됩니다 (기본 정렬은 최신순)
+* progress, category 파라미터가 없는 경우 전체 게시물이 조회됩니다.
+* progress는 파라미터로 리스트, 단일 값 모두 필터링 가능합니다.
+* ex. progress=INPROGRESS,PENDING (o) /
+progress=INPROGRESS(o)
 
+== 전체조회 - OWNER
 === HttpRequest
 
-include::{snippets}/get-repair-article-list/http-request.adoc[]
-include::{snippets}/get-repair-article-list/query-parameters.adoc[]
+include::{snippets}/get-owner-repair-article-list/http-request.adoc[]
+include::{snippets}/get-owner-repair-article-list/query-parameters.adoc[]
 
 === HttpResponse
 
-include::{snippets}/get-repair-article-list/http-response.adoc[]
-include::{snippets}/get-repair-article-list/response-fields.adoc[]
+include::{snippets}/get-owner-repair-article-list/http-response.adoc[]
+include::{snippets}/get-owner-repair-article-list/response-fields.adoc[]
+
+== 전체조회 - MANAGER
+=== HttpRequest
+
+include::{snippets}/get-manager-repair-article-list/http-request.adoc[]
+include::{snippets}/get-manager-repair-article-list/query-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/get-manager-repair-article-list/http-response.adoc[]
+include::{snippets}/get-manager-repair-article-list/response-fields.adoc[]
 
 [[Get-Repair-Article-Detail]]
 == 유지보수 게시글 상세 조회

--- a/src/main/java/com/final_10aeat/domain/repairArticle/controller/GetRepairArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/controller/GetRepairArticleController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/repair/articles")
-public class OwnerRepairArticleController {
+public class GetRepairArticleController {
 
     private final AuthenticationService authenticationService;
     private final GetRepairArticleFacade getRepairArticleFacade;

--- a/src/main/java/com/final_10aeat/domain/repairArticle/controller/GetRepairArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/controller/GetRepairArticleController.java
@@ -1,9 +1,7 @@
 package com.final_10aeat.domain.repairArticle.controller;
 
-import com.final_10aeat.common.dto.UserIdAndRole;
 import com.final_10aeat.common.enumclass.ArticleCategory;
 import com.final_10aeat.common.enumclass.Progress;
-import com.final_10aeat.common.service.AuthenticationService;
 import com.final_10aeat.domain.repairArticle.dto.response.CustomProgressResponseDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleDetailDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleSummaryDto;
@@ -25,14 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/repair/articles")
 public class GetRepairArticleController {
 
-    private final AuthenticationService authenticationService;
     private final GetRepairArticleFacade getRepairArticleFacade;
 
     @GetMapping("/summary")
     public ResponseEntity<ResponseDTO<RepairArticleSummaryDto>> getRepairArticleSummary() {
-        Long officeId = authenticationService.getUserOfficeId();
-        RepairArticleSummaryDto summary = getRepairArticleFacade.getRepairArticleSummary(
-            officeId);
+        RepairArticleSummaryDto summary = getRepairArticleFacade.getRepairArticleSummary();
         return ResponseEntity.ok(ResponseDTO.okWithData(summary));
     }
 
@@ -42,19 +37,16 @@ public class GetRepairArticleController {
         @RequestParam(required = false) ArticleCategory category) {
 
         List<Progress> progressList = determineProgressFilter(progress);
-        UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
 
-        List<?> articles = getRepairArticleFacade.getAllRepairArticles(
-            userIdAndRole, progressList, category);
+        List<?> articles = getRepairArticleFacade.getAllRepairArticles(progressList, category);
         return ResponseEntity.ok(ResponseDTO.okWithData(articles));
     }
 
     @GetMapping("/{repairArticleId}")
     public ResponseEntity<ResponseDTO<RepairArticleDetailDto>> getRepairArticleDetail(
         @PathVariable Long repairArticleId) {
-        UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
         RepairArticleDetailDto articleDetails = getRepairArticleFacade.getArticleDetails(
-            repairArticleId, userIdAndRole.id(), userIdAndRole.isManager());
+            repairArticleId);
 
         return ResponseEntity.ok(ResponseDTO.okWithData(articleDetails));
     }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/controller/OwnerRepairArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/controller/OwnerRepairArticleController.java
@@ -6,9 +6,8 @@ import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.common.service.AuthenticationService;
 import com.final_10aeat.domain.repairArticle.dto.response.CustomProgressResponseDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleDetailDto;
-import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleResponseDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleSummaryDto;
-import com.final_10aeat.domain.repairArticle.service.OwnerRepairArticleService;
+import com.final_10aeat.domain.repairArticle.service.GetRepairArticleFacade;
 import com.final_10aeat.global.util.ResponseDTO;
 import java.util.Arrays;
 import java.util.List;
@@ -26,26 +25,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/repair/articles")
 public class OwnerRepairArticleController {
 
-    private final OwnerRepairArticleService ownerRepairArticleService;
     private final AuthenticationService authenticationService;
+    private final GetRepairArticleFacade getRepairArticleFacade;
 
     @GetMapping("/summary")
     public ResponseEntity<ResponseDTO<RepairArticleSummaryDto>> getRepairArticleSummary() {
         Long officeId = authenticationService.getUserOfficeId();
-        RepairArticleSummaryDto summary = ownerRepairArticleService.getRepairArticleSummary(
+        RepairArticleSummaryDto summary = getRepairArticleFacade.getRepairArticleSummary(
             officeId);
         return ResponseEntity.ok(ResponseDTO.okWithData(summary));
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ResponseDTO<List<RepairArticleResponseDto>>> getAllRepairArticles(
+    public ResponseEntity<ResponseDTO<List<?>>> getAllRepairArticles(
         @RequestParam(required = false) List<String> progress,
         @RequestParam(required = false) ArticleCategory category) {
 
         List<Progress> progressList = determineProgressFilter(progress);
         UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
 
-        List<RepairArticleResponseDto> articles = ownerRepairArticleService.getAllRepairArticles(
+        List<?> articles = getRepairArticleFacade.getAllRepairArticles(
             userIdAndRole, progressList, category);
         return ResponseEntity.ok(ResponseDTO.okWithData(articles));
     }
@@ -54,7 +53,7 @@ public class OwnerRepairArticleController {
     public ResponseEntity<ResponseDTO<RepairArticleDetailDto>> getRepairArticleDetail(
         @PathVariable Long repairArticleId) {
         UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
-        RepairArticleDetailDto articleDetails = ownerRepairArticleService.getArticleDetails(
+        RepairArticleDetailDto articleDetails = getRepairArticleFacade.getArticleDetails(
             repairArticleId, userIdAndRole.id(), userIdAndRole.isManager());
 
         return ResponseEntity.ok(ResponseDTO.okWithData(articleDetails));
@@ -63,7 +62,7 @@ public class OwnerRepairArticleController {
     @GetMapping("/progress/{repairArticleId}")
     public ResponseEntity<ResponseDTO<List<CustomProgressResponseDto>>> getCustomProgressList(
         @PathVariable Long repairArticleId) {
-        List<CustomProgressResponseDto> customProgressList = ownerRepairArticleService.getCustomProgressList(
+        List<CustomProgressResponseDto> customProgressList = getRepairArticleFacade.getCustomProgressList(
             repairArticleId);
         return ResponseEntity.ok(ResponseDTO.okWithData(customProgressList));
     }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/dto/response/ManagerRepairArticleResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/dto/response/ManagerRepairArticleResponseDto.java
@@ -1,0 +1,20 @@
+package com.final_10aeat.domain.repairArticle.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ManagerRepairArticleResponseDto(
+    Long id,
+    String category,
+    String managerName,
+    String progress,
+    String title,
+    LocalDateTime startConstruction,
+    LocalDateTime endConstruction,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    int commentCount,
+    int viewCount,
+    String imageUrl
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/dto/response/OwnerRepairArticleResponseDto.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/dto/response/OwnerRepairArticleResponseDto.java
@@ -2,7 +2,7 @@ package com.final_10aeat.domain.repairArticle.dto.response;
 
 import java.time.LocalDateTime;
 
-public record RepairArticleResponseDto(
+public record OwnerRepairArticleResponseDto(
     Long id,
     String category,
     String managerName,
@@ -15,7 +15,6 @@ public record RepairArticleResponseDto(
     int viewCount,
     boolean isSave,
     boolean redDot,
-    boolean isNewArticle,
     String imageUrl
 ) {
 

--- a/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleRepository.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleRepository.java
@@ -24,8 +24,9 @@ public interface RepairArticleRepository extends JpaRepository<RepairArticle, Lo
 
     @Query("SELECT ra FROM RepairArticle ra WHERE ra.office.id = :officeId " +
         "AND (:progresses IS NULL OR ra.progress IN :progresses) " +
-        "AND (:category IS NULL OR ra.category = :category)")
-    List<RepairArticle> findByOfficeIdAndProgressInAndCategory(
+        "AND (:category IS NULL OR ra.category = :category)" +
+        "ORDER BY ra.id DESC")
+    List<RepairArticle> findByOfficeIdAndProgressInAndCategoryOrderByCreatedAtDesc(
         @Param("officeId") Long officeId,
         @Param("progresses") List<Progress> progresses,
         @Param("category") ArticleCategory category);

--- a/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleRepository.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleRepository.java
@@ -11,7 +11,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface RepairArticleRepository extends JpaRepository<RepairArticle, Long> {
 
-    @Query("SELECT r FROM RepairArticle r WHERE r.deletedAt IS NOT NULL AND r.deletedAt < :cutoffDate")
+    @Query("""
+           SELECT r
+           FROM RepairArticle r
+           WHERE r.deletedAt IS NOT NULL
+           AND r.deletedAt < :cutoffDate
+           """)
     List<RepairArticle> findSoftDeletedBefore(LocalDateTime cutoffDate);
 
     long countByOfficeIdAndProgressIn(@Param("officeId") Long officeId,
@@ -22,17 +27,25 @@ public interface RepairArticleRepository extends JpaRepository<RepairArticle, Lo
 
     long countByOfficeId(@Param("officeId") Long officeId);
 
-    @Query("SELECT ra FROM RepairArticle ra WHERE ra.office.id = :officeId " +
-        "AND (:progresses IS NULL OR ra.progress IN :progresses) " +
-        "AND (:category IS NULL OR ra.category = :category)" +
-        "ORDER BY ra.id DESC")
+    @Query("""
+           SELECT ra
+           FROM RepairArticle ra
+           WHERE ra.office.id = :officeId
+           AND (:progresses IS NULL OR ra.progress IN :progresses)
+           AND (:category IS NULL OR ra.category = :category)
+           ORDER BY ra.id DESC
+           """)
     List<RepairArticle> findByOfficeIdAndProgressInAndCategoryOrderByCreatedAtDesc(
         @Param("officeId") Long officeId,
         @Param("progresses") List<Progress> progresses,
         @Param("category") ArticleCategory category);
 
-    @Query("SELECT ra FROM RepairArticle ra WHERE ra.office.id = :officeId " +
-        "AND ra.progress IN :progresses")
+    @Query("""
+           SELECT ra
+           FROM RepairArticle ra
+           WHERE ra.office.id = :officeId
+           AND ra.progress IN :progresses
+           """)
     List<RepairArticle> findByOfficeIdAndProgressIn(
         @Param("officeId") Long officeId,
         @Param("progresses") List<Progress> progresses);

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleFacade.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleFacade.java
@@ -20,26 +20,27 @@ public class GetRepairArticleFacade {
     private final GetRepairArticleService getRepairArticleService;
     private final AuthenticationService authenticationService;
 
-    public List<?> getAllRepairArticles(UserIdAndRole userIdAndRole, List<Progress> progresses,
-        ArticleCategory category) {
+    public List<?> getAllRepairArticles(List<Progress> progresses, ArticleCategory category) {
+        UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
         Long officeId = authenticationService.getUserOfficeId();
         if (userIdAndRole.isManager()) {
-            return managerArticleListService.getAllRepairArticles(officeId, progresses,
-                category);
+            return managerArticleListService.getAllRepairArticles(officeId, progresses, category);
         } else {
             return ownerArticleListService.getAllRepairArticles(officeId, userIdAndRole.id(),
                 progresses, category);
         }
     }
 
-    public RepairArticleSummaryDto getRepairArticleSummary(Long officeId) {
+    public RepairArticleSummaryDto getRepairArticleSummary() {
+        Long officeId = authenticationService.getUserOfficeId();
         UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
         return getRepairArticleService.getRepairArticleSummary(officeId, userIdAndRole);
     }
 
-    public RepairArticleDetailDto getArticleDetails(Long articleId, Long userId,
-        boolean isManager) {
-        return getRepairArticleService.getArticleDetails(articleId, userId, isManager);
+    public RepairArticleDetailDto getArticleDetails(Long articleId) {
+        UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
+        return getRepairArticleService.getArticleDetails(articleId, userIdAndRole.id(),
+            userIdAndRole.isManager());
     }
 
     public List<CustomProgressResponseDto> getCustomProgressList(Long articleId) {

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleFacade.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleFacade.java
@@ -1,0 +1,48 @@
+package com.final_10aeat.domain.repairArticle.service;
+
+import com.final_10aeat.common.dto.UserIdAndRole;
+import com.final_10aeat.common.enumclass.ArticleCategory;
+import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.common.service.AuthenticationService;
+import com.final_10aeat.domain.repairArticle.dto.response.CustomProgressResponseDto;
+import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleDetailDto;
+import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleSummaryDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetRepairArticleFacade {
+
+    private final ManagerArticleListService managerArticleListService;
+    private final OwnerArticleListService ownerArticleListService;
+    private final GetRepairArticleService getRepairArticleService;
+    private final AuthenticationService authenticationService;
+
+    public List<?> getAllRepairArticles(UserIdAndRole userIdAndRole, List<Progress> progresses,
+        ArticleCategory category) {
+        Long officeId = authenticationService.getUserOfficeId();
+        if (userIdAndRole.isManager()) {
+            return managerArticleListService.getAllRepairArticles(officeId, progresses,
+                category);
+        } else {
+            return ownerArticleListService.getAllRepairArticles(officeId, userIdAndRole.id(),
+                progresses, category);
+        }
+    }
+
+    public RepairArticleSummaryDto getRepairArticleSummary(Long officeId) {
+        UserIdAndRole userIdAndRole = authenticationService.getCurrentUserIdAndRole();
+        return getRepairArticleService.getRepairArticleSummary(officeId, userIdAndRole);
+    }
+
+    public RepairArticleDetailDto getArticleDetails(Long articleId, Long userId,
+        boolean isManager) {
+        return getRepairArticleService.getArticleDetails(articleId, userId, isManager);
+    }
+
+    public List<CustomProgressResponseDto> getCustomProgressList(Long articleId) {
+        return getRepairArticleService.getCustomProgressList(articleId);
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
@@ -1,15 +1,11 @@
 package com.final_10aeat.domain.repairArticle.service;
 
 import com.final_10aeat.common.dto.UserIdAndRole;
-import com.final_10aeat.common.enumclass.ArticleCategory;
 import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.common.exception.ArticleNotFoundException;
-import com.final_10aeat.common.service.AuthenticationService;
 import com.final_10aeat.domain.articleIssue.repository.ArticleIssueCheckRepository;
-import com.final_10aeat.domain.comment.repository.CommentRepository;
 import com.final_10aeat.domain.repairArticle.dto.response.CustomProgressResponseDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleDetailDto;
-import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleResponseDto;
 import com.final_10aeat.domain.repairArticle.dto.response.RepairArticleSummaryDto;
 import com.final_10aeat.domain.repairArticle.entity.ArticleView;
 import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
@@ -18,10 +14,6 @@ import com.final_10aeat.domain.repairArticle.entity.RepairArticleImage;
 import com.final_10aeat.domain.repairArticle.repository.ArticleViewRepository;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
 import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,120 +22,46 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class OwnerRepairArticleService {
+public class GetRepairArticleService {
 
     private final RepairArticleRepository repairArticleRepository;
-    private final CommentRepository commentRepository;
     private final ArticleSaveRepository articleSaveRepository;
     private final ArticleIssueCheckRepository articleIssueCheckRepository;
     private final ArticleViewRepository articleViewRepository;
-    private final AuthenticationService authenticationService;
 
-    @Transactional(readOnly = true)
-    public RepairArticleSummaryDto getRepairArticleSummary(Long officeId) {
+    public RepairArticleSummaryDto getRepairArticleSummary(Long officeId,
+        UserIdAndRole userIdAndRole) {
         long total = repairArticleRepository.countByOfficeId(officeId);
         long inProgressAndPending = repairArticleRepository.countByOfficeIdAndProgressIn(officeId,
             List.of(Progress.INPROGRESS, Progress.PENDING));
         long completed = repairArticleRepository.countByOfficeIdAndProgress(officeId,
             Progress.COMPLETE);
 
-        List<RepairArticle> inProgressArticles = repairArticleRepository.findByOfficeIdAndProgressIn(officeId,
+        List<RepairArticle> inProgressArticles = repairArticleRepository.findByOfficeIdAndProgressIn(
+            officeId,
             List.of(Progress.INPROGRESS, Progress.PENDING));
-        List<RepairArticle> completeArticles = repairArticleRepository.findByOfficeIdAndProgressIn(officeId,
+        List<RepairArticle> completeArticles = repairArticleRepository.findByOfficeIdAndProgressIn(
+            officeId,
             List.of(Progress.COMPLETE));
 
         boolean inProgressRedDot = inProgressArticles.stream()
-            .anyMatch(this::hasRedDotIssue);
+            .anyMatch(article -> hasRedDotIssue(article, userIdAndRole));
 
         boolean completeRedDot = completeArticles.stream()
-            .anyMatch(this::hasRedDotIssue);
+            .anyMatch(article -> hasRedDotIssue(article, userIdAndRole));
 
-        return new RepairArticleSummaryDto(total, inProgressAndPending, inProgressRedDot, completed, completeRedDot);
+        return new RepairArticleSummaryDto(total, inProgressAndPending, inProgressRedDot, completed,
+            completeRedDot);
     }
 
-    private boolean hasRedDotIssue(RepairArticle article) {
-        UserIdAndRole currentUser = authenticationService.getCurrentUserIdAndRole();
-        Long userId = currentUser.id();
-        boolean isManager = currentUser.isManager();
+    private boolean hasRedDotIssue(RepairArticle article, UserIdAndRole userIdAndRole) {
+        Long userId = userIdAndRole.id();
         Set<Long> checkedIssueIds = articleIssueCheckRepository.findCheckedIssueIdsByMember(userId);
-        return !isManager && article.hasIssue() && !checkedIssueIds.contains(article.getIssue().getId());
+        return article.hasIssue() && !checkedIssueIds.contains(article.getIssue().getId());
     }
 
-    @Transactional(readOnly = true)
-    public List<RepairArticleResponseDto> getAllRepairArticles(UserIdAndRole userIdAndRole,
-        List<Progress> progresses, ArticleCategory category) {
-        Long officeId = authenticationService.getUserOfficeId();
-        List<RepairArticle> articles = repairArticleRepository.findByOfficeIdAndProgressInAndCategory(
-            officeId, progresses, category);
-
-        Set<Long> savedArticleIds;
-        Set<Long> checkedIssueIds;
-        boolean isManager = userIdAndRole.isManager();
-
-        if (!isManager) {
-            List<Long> articleIds = articles.stream().map(RepairArticle::getId)
-                .collect(Collectors.toList());
-            savedArticleIds = articleSaveRepository.findSavedArticleIdsByMember(userIdAndRole.id(),
-                articleIds);
-            checkedIssueIds = articleIssueCheckRepository.findCheckedIssueIdsByMember(
-                userIdAndRole.id());
-        } else {
-            checkedIssueIds = new HashSet<>();
-            savedArticleIds = new HashSet<>();
-        }
-
-        List<RepairArticleResponseDto> isNewArticleList = articles.stream()
-            .map(article -> mapToDto(article, savedArticleIds, checkedIssueIds, isManager))
-            .filter(RepairArticleResponseDto::isNewArticle)
-            .sorted(Comparator.comparing(RepairArticleResponseDto::createdAt).reversed())
-            .toList();
-
-        List<RepairArticleResponseDto> isNotNewArticleList = articles.stream()
-            .map(article -> mapToDto(article, savedArticleIds, checkedIssueIds, isManager))
-            .filter(dto -> !dto.isNewArticle())
-            .sorted(Comparator.comparing(RepairArticleResponseDto::redDot)
-                .thenComparing(RepairArticleResponseDto::createdAt).reversed())
-            .toList();
-
-        List<RepairArticleResponseDto> sortedArticles = new ArrayList<>();
-        sortedArticles.addAll(isNewArticleList);
-        sortedArticles.addAll(isNotNewArticleList);
-
-        return sortedArticles;
-    }
-
-    private RepairArticleResponseDto mapToDto(RepairArticle article, Set<Long> savedArticleIds,
-        Set<Long> checkedIssueIds, boolean isManager) {
-        boolean isNewArticle = article.getCreatedAt().plusDays(1).isAfter(LocalDateTime.now());
-        int commentCount = (int) commentRepository.countByRepairArticleIdAndDeletedAtIsNull(
-            article.getId());
-        boolean isSaved = savedArticleIds.contains(article.getId());
-        boolean hasIssue = !isManager && article.hasIssue() && !checkedIssueIds.contains(
-            article.getIssue().getId());
-        int viewCount = article.getViewCount();
-
-        return new RepairArticleResponseDto(
-            article.getId(),
-            article.getCategory().name(),
-            article.getManager().getName(),
-            article.getProgress().name(),
-            article.getTitle(),
-            article.getStartConstruction(),
-            article.getEndConstruction(),
-            article.getCreatedAt(),
-            commentCount,
-            viewCount,
-            isSaved,
-            hasIssue,
-            isNewArticle,
-            article.getImages().isEmpty() ? null
-                : article.getImages().iterator().next().getImageUrl()
-        );
-    }
-
-    @Transactional(readOnly = true)
     public RepairArticleDetailDto getArticleDetails(Long articleId, Long userId,
         boolean isManager) {
         incrementViewCount(articleId, userId, isManager);
@@ -193,7 +111,6 @@ public class OwnerRepairArticleService {
         }
     }
 
-    @Transactional(readOnly = true)
     public List<CustomProgressResponseDto> getCustomProgressList(Long articleId) {
         RepairArticle article = repairArticleRepository.findById(articleId)
             .orElseThrow(ArticleNotFoundException::new);

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
@@ -26,7 +26,6 @@ public class ManagerArticleListService {
             officeId, progresses, category);
 
         return articles.stream()
-            .sorted((a, b) -> b.getCreatedAt().compareTo(a.getUpdatedAt()))
             .map(this::mapToDto)
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
@@ -1,0 +1,55 @@
+package com.final_10aeat.domain.repairArticle.service;
+
+import com.final_10aeat.common.enumclass.ArticleCategory;
+import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.domain.repairArticle.dto.response.ManagerRepairArticleResponseDto;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.domain.comment.repository.CommentRepository;
+import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerArticleListService {
+
+    private final RepairArticleRepository repairArticleRepository;
+    private final CommentRepository commentRepository;
+
+    public List<ManagerRepairArticleResponseDto> getAllRepairArticles(Long officeId,
+        List<Progress> progresses, ArticleCategory category) {
+        List<RepairArticle> articles = repairArticleRepository.findByOfficeIdAndProgressInAndCategoryOrderByCreatedAtDesc(
+            officeId, progresses, category);
+
+        return articles.stream()
+            .sorted((a, b) -> b.getCreatedAt().compareTo(a.getUpdatedAt()))
+            .map(this::mapToDto)
+            .collect(Collectors.toList());
+    }
+
+    private ManagerRepairArticleResponseDto mapToDto(RepairArticle article) {
+        int commentCount = (int) commentRepository.countByRepairArticleIdAndDeletedAtIsNull(
+            article.getId());
+        int viewCount = article.getViewCount();
+
+        return new ManagerRepairArticleResponseDto(
+            article.getId(),
+            article.getCategory().name(),
+            article.getManager().getName(),
+            article.getProgress().name(),
+            article.getTitle(),
+            article.getStartConstruction(),
+            article.getEndConstruction(),
+            article.getCreatedAt(),
+            article.getUpdatedAt(),
+            commentCount,
+            viewCount,
+            article.getImages().isEmpty() ? null
+                : article.getImages().iterator().next().getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/OwnerArticleListService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/OwnerArticleListService.java
@@ -1,0 +1,74 @@
+package com.final_10aeat.domain.repairArticle.service;
+
+import com.final_10aeat.common.enumclass.ArticleCategory;
+import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.domain.articleIssue.repository.ArticleIssueCheckRepository;
+import com.final_10aeat.domain.comment.repository.CommentRepository;
+import com.final_10aeat.domain.repairArticle.dto.response.OwnerRepairArticleResponseDto;
+import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
+import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
+import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OwnerArticleListService {
+
+    private final RepairArticleRepository repairArticleRepository;
+    private final CommentRepository commentRepository;
+    private final ArticleSaveRepository articleSaveRepository;
+    private final ArticleIssueCheckRepository articleIssueCheckRepository;
+
+    public List<OwnerRepairArticleResponseDto> getAllRepairArticles(Long officeId, Long userId,
+        List<Progress> progresses, ArticleCategory category) {
+        List<RepairArticle> articles = repairArticleRepository.findByOfficeIdAndProgressInAndCategoryOrderByCreatedAtDesc(
+            officeId, progresses, category);
+
+        Set<Long> savedArticleIds;
+        Set<Long> checkedIssueIds;
+
+        List<Long> articleIds = articles.stream().map(RepairArticle::getId)
+            .collect(Collectors.toList());
+        savedArticleIds = articleSaveRepository.findSavedArticleIdsByMember(userId, articleIds);
+        checkedIssueIds = articleIssueCheckRepository.findCheckedIssueIdsByMember(userId);
+
+        return articles.stream()
+            .map(article -> mapToDto(article, savedArticleIds, checkedIssueIds))
+            .sorted(Comparator.comparing(OwnerRepairArticleResponseDto::redDot).reversed())
+            .collect(Collectors.toList());
+    }
+
+    private OwnerRepairArticleResponseDto mapToDto(RepairArticle article, Set<Long> savedArticleIds,
+        Set<Long> checkedIssueIds) {
+        int commentCount = (int) commentRepository.countByRepairArticleIdAndDeletedAtIsNull(
+            article.getId());
+        boolean isSaved = savedArticleIds.contains(article.getId());
+        boolean hasIssue =
+            article.hasIssue() && !checkedIssueIds.contains(article.getIssue().getId());
+        int viewCount = article.getViewCount();
+
+        return new OwnerRepairArticleResponseDto(
+            article.getId(),
+            article.getCategory().name(),
+            article.getManager().getName(),
+            article.getProgress().name(),
+            article.getTitle(),
+            article.getStartConstruction(),
+            article.getEndConstruction(),
+            article.getCreatedAt(),
+            commentCount,
+            viewCount,
+            isSaved,
+            hasIssue,
+            article.getImages().isEmpty() ? null
+                : article.getImages().iterator().next().getImageUrl()
+        );
+    }
+}

--- a/src/test/java/com/final_10aeat/domain/repairArticle/docs/GetRepairArticleDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/repairArticle/docs/GetRepairArticleDocsTest.java
@@ -43,7 +43,7 @@ public class GetRepairArticleDocsTest extends RestDocsSupport {
     public Object initController() {
         getRepairArticleFacade = mock(GetRepairArticleFacade.class);
         authenticationService = mock(AuthenticationService.class);
-        return new GetRepairArticleController(authenticationService, getRepairArticleFacade);
+        return new GetRepairArticleController(getRepairArticleFacade);
     }
 
     @DisplayName("유지보수 게시글 요약 조회 API 문서화")
@@ -62,7 +62,7 @@ public class GetRepairArticleDocsTest extends RestDocsSupport {
             false
         );
 
-        when(getRepairArticleFacade.getRepairArticleSummary(1L)).thenReturn(summaryDto);
+        when(getRepairArticleFacade.getRepairArticleSummary()).thenReturn(summaryDto);
 
         // when & then
         mockMvc.perform(get("/repair/articles/summary")
@@ -109,7 +109,7 @@ public class GetRepairArticleDocsTest extends RestDocsSupport {
         );
 
         List<OwnerRepairArticleResponseDto> articles = List.of(articleDto1, articleDto2);
-        when(getRepairArticleFacade.getAllRepairArticles(userIdAndRole,
+        when(getRepairArticleFacade.getAllRepairArticles(
             List.of(Progress.INPROGRESS, Progress.PENDING), ArticleCategory.REPAIR)).thenReturn(
             (List) articles);
 
@@ -183,7 +183,7 @@ public class GetRepairArticleDocsTest extends RestDocsSupport {
         );
 
         List<ManagerRepairArticleResponseDto> articles = List.of(articleDto1, articleDto2);
-        when(getRepairArticleFacade.getAllRepairArticles(userIdAndRole,
+        when(getRepairArticleFacade.getAllRepairArticles(
             List.of(Progress.PENDING), null)).thenReturn((List) articles);
 
         // when & then
@@ -243,8 +243,7 @@ public class GetRepairArticleDocsTest extends RestDocsSupport {
             "수리회사 이름", "http://repaircompany.com"
         );
 
-        when(getRepairArticleFacade.getArticleDetails(1L, userIdAndRole.id(),
-            userIdAndRole.isManager())).thenReturn(detailDto);
+        when(getRepairArticleFacade.getArticleDetails(1L)).thenReturn(detailDto);
 
         // when & then
         mockMvc.perform(get("/repair/articles/{repairArticleId}", 1L)


### PR DESCRIPTION
# ⭐️ [Refactor] 유지보수 게시글 조회 기능 리팩토링

- 최신순 정렬을 따로 하는 대신 데이터베이스 조회 시에 id 를 desc로 불러와 자동 정렬되게 수정
- facade 패턴 적용
- GET /repair/articles/list 조회시에 현재 로그인한 사용자에 따라 응답값 분리
- 24시간 이내에 생성된 게시물임을 나타내는 isNewArticle 로직 삭제(프론트가 처리하도록 변경)

## 🛠️ 변경 사항

커밋 메시지에 자세히 적어두었으니 커밋 메시지 참고하시길 바랍니다.

## 💡 관련 이슈

- #147

## ❗️ 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트


## ⏱️ 작업 기간

- 작업 시작일: (2024-06-03)
- 작업 종료일: (2024-06-03)

## 📌 유의사항

- 테스트 코드 수정은 후에 커밋 예정이니 수정된 로직만 봐주시면 됩니다!

