### PR TITLE
[refactor] 목록조회 파라미터 추가

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
@@ -49,14 +49,16 @@ public class ReadManageArticleController {
 
     @GetMapping("/list")
     public ResponseDTO<List<ListManageArticleResponse>> listArticle(
-        @RequestParam(required = false) Integer year
+        @RequestParam(required = false) Integer year,
+        @RequestParam(required = false) Boolean complete
     ) {
         Long userOfficeId = authenticationService.getUserOfficeId();
 
         return ResponseDTO.okWithData(
             readManageArticleService.listArticle(
                 ofNullable(year).orElseGet(() -> LocalDate.now().getYear()),
-                userOfficeId
+                userOfficeId,
+                complete
             )
         );
     }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleRepository.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleRepository.java
@@ -1,14 +1,22 @@
 package com.final_10aeat.domain.manageArticle.repository;
 
+import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManageArticleRepository extends JpaRepository<ManageArticle, Long>, ManageArticleQueryDslRepository {
+public interface ManageArticleRepository extends JpaRepository<ManageArticle, Long>,
+    ManageArticleQueryDslRepository {
 
     List<ManageArticle> findAllByDeletedAtBeforeAndDeletedAtNotNull(LocalDateTime createdAt);
+
     List<ManageArticle> findAllByOfficeIdAndDeletedAtNull(Long id);
+
+    List<ManageArticle> findAllByOfficeIdAndDeletedAtNullAndProgressIn(
+        Long office_id, List<Progress> progress
+    );
+
     Optional<ManageArticle> findByIdAndDeletedAtNull(Long id);
 }

--- a/src/test/java/com/final_10aeat/domain/manageArticle/docs/ReadManageArticleControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/docs/ReadManageArticleControllerDocsTest.java
@@ -192,18 +192,23 @@ public class ReadManageArticleControllerDocsTest extends RestDocsSupport {
         );
 
         given(authenticationService.getUserOfficeId()).willReturn(1L);
-        given(readManageArticleService.listArticle(anyInt(), anyLong())).willReturn(responseList);
+        given(readManageArticleService.listArticle(anyInt(), anyLong(), any())).willReturn(
+            responseList);
 
         // when & then
         mockMvc.perform(get("/manage/articles/list")
                 .contentType(MediaType.APPLICATION_JSON)
+                .param("year", "2024")
+                .param("complete", "true")
             )
             .andExpect(status().isOk())
             .andDo(document("get-manage-article-list",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     pathParameters(
-                        parameterWithName("year").description("일정이 있는 연도, null인 경우 당 년도").optional()
+                        parameterWithName("year").description("일정이 있는 연도, null인 경우 당 년도").optional(),
+                        parameterWithName("complete").description(
+                            "true = 완료, false = 진행중&대기, null인 경우 전체 검색").optional()
                     ),
                     responseFields(
                         fieldWithPath("code").type(NUMBER).description("응답 상태 코드"),
@@ -266,13 +271,13 @@ public class ReadManageArticleControllerDocsTest extends RestDocsSupport {
         );
 
         given(authenticationService.getUserOfficeId()).willReturn(1L);
-        given(readManageArticleService.monthlyListArticle(anyLong(),anyInt(),any()))
+        given(readManageArticleService.monthlyListArticle(anyLong(), anyInt(), any()))
             .willReturn(responseList);
 
         // when & then
         mockMvc.perform(get("/manage/articles/monthly/list")
-                .param("year","2024")
-                .param("month","1")
+                .param("year", "2024")
+                .param("month", "1")
                 .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk())

--- a/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
@@ -167,7 +167,7 @@ public class ReadManageArticleServiceTest {
 
         // when
         List<ListManageArticleResponse> result =
-            readManageArticleService.listArticle(2024, 1L);
+            readManageArticleService.listArticle(2024, 1L, null);
 
         // then
         assertThat(result.size()).isEqualTo(1);


### PR DESCRIPTION

# Pull Request 요약

- 목록 조회 시, Parameter 받을 수 있도록 Refactoring & 문서 업데이트

## 변경 사항

- ManageArticleRepository: 진행도별 검색메소드 추가
- ReadManageArticleController : list 진행도별 검색 메소드 추가
- ReadManageArticleControllerDocsTest : 전체 목록 조회 문서 업데이트
- ReadManageArticleService : list 진행도별 검색 메소드 추가
- ReadManageArticleServiceTest : 테스트코드 업데이트

## 관련 이슈

- #172 

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [X] 리팩토링
- [x] 테스트 코드 작성
- [x] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-06-10)
- 작업 종료일: (2024-06-10)
