### PR TITLE
[Refactor] 요약 조회에서 총 게시글 수를 보여준다

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
@@ -6,12 +6,12 @@ import static java.util.Optional.ofNullable;
 import com.final_10aeat.common.service.AuthenticationService;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
+import com.final_10aeat.domain.manageArticle.dto.response.ManageArticleSummaryResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.SummaryManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.service.ReadManageArticleService;
 import com.final_10aeat.global.util.ResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,7 +64,7 @@ public class ReadManageArticleController {
     }
 
     @GetMapping("/monthly/summary")
-    public ResponseDTO<Set<Integer>> monthlySummary(
+    public ResponseDTO<List<ManageArticleSummaryResponse>> monthlySummary(
         @RequestParam(required = false) Integer year
     ) {
         Long userOfficeId = authenticationService.getUserOfficeId();

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/response/ManageArticleSummaryResponse.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/response/ManageArticleSummaryResponse.java
@@ -1,0 +1,8 @@
+package com.final_10aeat.domain.manageArticle.dto.response;
+
+public record ManageArticleSummaryResponse(
+    Integer month,
+    Integer total
+) {
+
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
@@ -8,12 +8,14 @@ import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.articleIssue.entity.ArticleIssue;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
+import com.final_10aeat.domain.manageArticle.dto.response.ManageArticleSummaryResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.SummaryManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.util.ScheduleConverter;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import com.final_10aeat.domain.manageArticle.entity.ManageSchedule;
 import com.final_10aeat.domain.manageArticle.repository.ManageArticleRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -146,18 +148,29 @@ public class ReadManageArticleService {
             .build();
     }
 
-    public Set<Integer> monthlySummary(Integer year, Long officeId) {
-        Set<Integer> monthly = new HashSet<>();
-        List<ManageArticle> articles = manageArticleRepository
-            .findAllByOfficeIdAndDeletedAtNull(officeId);
+    public List<ManageArticleSummaryResponse> monthlySummary(Integer year, Long officeId) {
+        List<ManageArticle> articles = manageArticleRepository.findAllByOfficeIdAndDeletedAtNull(
+            officeId);
+
+        return toSummaryDto(articles, year);
+    }
+
+    private List<ManageArticleSummaryResponse> toSummaryDto(List<ManageArticle> articles, Integer year) {
+        List<ManageArticleSummaryResponse> monthly = new ArrayList<>();
+        HashMap<Integer, Set<Long>> monthArticleIdMap = new HashMap<>();
 
         articles.forEach(
-            article -> article.getSchedules()
-                .stream().filter(
-                    manageSchedule -> manageSchedule.getYear().equals(year)
-                ).forEach(
-                    schedule -> monthly.add(schedule.getMonth())
-                )
+            article -> article.getSchedules().stream()
+                .filter(schedule -> schedule.getYear().equals(year))
+                .forEach(schedule -> {
+                    Integer month = schedule.getMonth();
+                    monthArticleIdMap.getOrDefault(month, new HashSet<>())
+                        .add(article.getId());
+                })
+        );
+
+        monthArticleIdMap.forEach(
+            (key, value) -> monthly.add(new ManageArticleSummaryResponse(key, value.size()))
         );
         return monthly;
     }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
@@ -155,7 +155,8 @@ public class ReadManageArticleService {
         return toSummaryDto(articles, year);
     }
 
-    private List<ManageArticleSummaryResponse> toSummaryDto(List<ManageArticle> articles, Integer year) {
+    private List<ManageArticleSummaryResponse> toSummaryDto(List<ManageArticle> articles,
+        Integer year) {
         List<ManageArticleSummaryResponse> monthly = new ArrayList<>();
         HashMap<Integer, Set<Long>> monthArticleIdMap = new HashMap<>();
 
@@ -164,7 +165,7 @@ public class ReadManageArticleService {
                 .filter(schedule -> schedule.getYear().equals(year))
                 .forEach(schedule -> {
                     Integer month = schedule.getMonth();
-                    monthArticleIdMap.getOrDefault(month, new HashSet<>())
+                    monthArticleIdMap.computeIfAbsent(month, k -> new HashSet<>())
                         .add(article.getId());
                 })
         );

--- a/src/test/java/com/final_10aeat/domain/manageArticle/docs/ReadManageArticleControllerDocsTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/docs/ReadManageArticleControllerDocsTest.java
@@ -28,12 +28,12 @@ import com.final_10aeat.docs.RestDocsSupport;
 import com.final_10aeat.domain.manageArticle.controller.ReadManageArticleController;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
+import com.final_10aeat.domain.manageArticle.dto.response.ManageArticleSummaryResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ManageScheduleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.SummaryManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.service.ReadManageArticleService;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -229,10 +229,16 @@ public class ReadManageArticleControllerDocsTest extends RestDocsSupport {
     @WithMember
     void testMonthlySummary() throws Exception {
         // given
-        Set<Integer> response = Set.of(1, 2, 3);
+        List<ManageArticleSummaryResponse> response =
+            List.of(
+                new ManageArticleSummaryResponse(1, 1),
+                new ManageArticleSummaryResponse(3, 2),
+                new ManageArticleSummaryResponse(6, 5)
+            );
 
         given(authenticationService.getUserOfficeId()).willReturn(1L);
-        given(readManageArticleService.monthlySummary(anyInt(), anyLong())).willReturn(response);
+        given(readManageArticleService.monthlySummary(anyInt(), anyLong()))
+            .willReturn(response);
 
         // when & then
         mockMvc.perform(get("/manage/articles/monthly/summary")
@@ -247,7 +253,9 @@ public class ReadManageArticleControllerDocsTest extends RestDocsSupport {
                     ),
                     responseFields(
                         fieldWithPath("code").type(NUMBER).description("응답 상태 코드"),
-                        fieldWithPath("data").type(ARRAY).description("일정이 있는 월 목록")
+                        fieldWithPath("data").type(ARRAY).description("응답 리스트"),
+                        fieldWithPath("data[].month").type(NUMBER).description("데이터가 존재하는 월"),
+                        fieldWithPath("data[].total").type(NUMBER).description("해당 월의 게시글 갯수")
                     )
                 )
             );


### PR DESCRIPTION
# Pull Request 요약

- 월별 요약시 총 게시글 수를 보여줄 수 있도록 변경

## 변경 사항

- 월별요약시 월별로 게시글 몇건 있는지 볼 수 있도록 변경
- ReadManageArticleController : 해당 메소드 리턴타입 변경
- ReadManageArticleService : 요약 목록 중복되지 않고 조회할 수 있도록 코드 수정
  - computeIfAbsent : 조회와 동시에 수정할 때 getOrDefault보다 효율적일 수 있음
  - 존재할경우 첫번째 key로 조회한 데이터, 그 외의 경우 Function의 리턴값이 반환됩니다
- ReadManageArticleControllerDocsTest : 변경된 api에 맞게 문서 업데이트

## 관련 이슈

- 이 PR은 어떤 이슈로부터 만들어졌나요? (예: `#123`)

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [x] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-06-10)
- 작업 종료일: (2024-06-10)

