### PR TITLE
[Fix] 유지보수 상세조회, 요약조회 db에러 수정

### DIFF
--- a/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssue.java
+++ b/src/main/java/com/final_10aeat/domain/articleIssue/entity/ArticleIssue.java
@@ -43,7 +43,7 @@ public class ArticleIssue extends SoftDeletableBaseTimeEntity {
 
     @Setter
     @Column(name = "is_enabled")
-    private boolean enabled;
+    private boolean enabled = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manage_article_id", referencedColumnName = "id")

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
@@ -64,6 +64,7 @@ public class GetRepairArticleService {
             .orElse(false);
     }
 
+    @Transactional
     public RepairArticleDetailDto getArticleDetails(Long articleId, Long userId,
         boolean isManager) {
         incrementViewCount(articleId, userId, isManager);


### PR DESCRIPTION
# ⭐️ [Fix] 유지보수 상세조회, 요약조회 db에러 수정

## 🛠️ 변경 사항

#### 유지보수 상세조회 db 에러
- 클래스 레벨의 읽기전용 트랜잭션이 잘못 적용되어 발생하는 문제였습니다. 
- GetRepairArticleService 클래스 getArticleDetails 메서드에 @Transactional을 추가해 해결하였습니다.

#### 유지보수 요약조회 db 에러
- boolean 타입의 enabled 에 null로 초기화 되어 발생하는 문제였습니다.
- enabled를 false로 초기화하여 해결하였습니다.

## 💡관련 이슈

- #177

## 📃 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트


## ⏱️ 작업 기간

- 작업 시작일: (2024-06-11)
- 작업 종료일: (2024-06-11)

## 📌 유의사항

- 에러 해결을 위해 해당 pr 머지시 ArticleIssue 테이블 한번 밀고 다시 생성할 예정입니다!

