### PR TITLE
[Refactor] List를 Page로 변경한다

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/controller/ReadManageArticleController.java
@@ -99,16 +99,20 @@ public class ReadManageArticleController {
     }
 
     @GetMapping("/monthly/list")
-    public ResponseDTO<List<ListManageArticleResponse>> monthlyListArticle(
+    public ResponseDTO<CustomPageDto<ListManageArticleResponse>> monthlyListArticle(
         @RequestParam(required = false) Integer year,
-        @RequestParam(required = false) Integer month
+        @RequestParam(required = false) Integer month,
+        @PageableDefault(size = 20, sort = "id", direction = Direction.DESC) Pageable pageRequest
     ) {
         Long userOfficeId = authenticationService.getUserOfficeId();
         return ResponseDTO.okWithData(
-            readManageArticleService.monthlyListArticle(
-                userOfficeId,
-                ofNullable(year).orElseGet(() -> LocalDate.now().getYear()),
-                month
+            PageConverter.convertToCustomPageDto(
+                readManageArticleService.monthlyListArticle(
+                    userOfficeId,
+                    ofNullable(year).orElseGet(() -> LocalDate.now().getYear()),
+                    month,
+                    pageRequest
+                )
             )
         );
     }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/GetMonthlyListWithYearQuery.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/GetMonthlyListWithYearQuery.java
@@ -1,0 +1,22 @@
+package com.final_10aeat.domain.manageArticle.dto.request;
+
+import org.springframework.data.domain.Pageable;
+
+public record GetMonthlyListWithYearQuery(
+    Integer year,
+    Integer month,
+    Long officeId,
+    Pageable pageRequest
+) {
+
+    public static GetMonthlyListWithYearQuery toQueryDto(
+        Integer year, Integer month, Long officeId, Pageable pageRequest
+    ) {
+        return new GetMonthlyListWithYearQuery(
+            year,
+            month,
+            officeId,
+            pageRequest
+        );
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/GetYearListQuery.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/GetYearListQuery.java
@@ -1,0 +1,19 @@
+package com.final_10aeat.domain.manageArticle.dto.request;
+
+import org.springframework.data.domain.Pageable;
+
+public record GetYearListQuery(
+    Integer year,
+    Long officeId,
+    Pageable pageRequest
+) {
+    public static GetYearListQuery toQueryDto(
+        Integer year, Long officeId, Pageable pageRequest
+    ) {
+        return new GetYearListQuery(
+            year,
+            officeId,
+            pageRequest
+        );
+    }
+}

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepository.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepository.java
@@ -1,6 +1,8 @@
 package com.final_10aeat.domain.manageArticle.repository;
 
 import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.domain.manageArticle.dto.request.GetMonthlyListWithYearQuery;
+import com.final_10aeat.domain.manageArticle.dto.request.GetYearListQuery;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -12,10 +14,11 @@ public interface ManageArticleQueryDslRepository {
         Long userOfficeId, String search, Pageable pageRequest
     );
 
-    Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYear(Long userOfficeId,
-        Integer year, Pageable pageRequest);
-
     Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYearAndProgress(
         Long userOfficeId, Integer year, Pageable pageRequest, List<Progress> progresses
     );
+
+    Page<ManageArticle> findAllByYear(GetYearListQuery queryDto);
+
+    Page<ManageArticle> findAllByYearAndMonthly(GetMonthlyListWithYearQuery queryDto);
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepository.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepository.java
@@ -1,6 +1,8 @@
 package com.final_10aeat.domain.manageArticle.repository;
 
+import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,5 +10,12 @@ public interface ManageArticleQueryDslRepository {
 
     Page<ManageArticle> searchByOfficeIdAndText(
         Long userOfficeId, String search, Pageable pageRequest
+    );
+
+    Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYear(Long userOfficeId,
+        Integer year, Pageable pageRequest);
+
+    Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYearAndProgress(
+        Long userOfficeId, Integer year, Pageable pageRequest, List<Progress> progresses
     );
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
@@ -1,14 +1,18 @@
 package com.final_10aeat.domain.manageArticle.repository;
 
+import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import com.final_10aeat.domain.manageArticle.entity.QManageArticle;
+import com.final_10aeat.domain.manageArticle.entity.QManageSchedule;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +42,53 @@ public class ManageArticleQueryDslRepositoryImpl implements ManageArticleQueryDs
             .offset(pageRequest.getOffset())
             .limit(pageRequest.getPageSize());
 
+        return sortAndFetchtoPage(pageRequest, manageArticle, query);
+    }
+
+    @Override
+    public Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYear(Long userOfficeId,
+        Integer year, Pageable pageRequest) {
+        QManageArticle manageArticle = QManageArticle.manageArticle;
+        QManageSchedule manageSchedule = QManageSchedule.manageSchedule;
+
+        JPAQuery<ManageArticle> query = queryFactory.selectFrom(manageArticle)
+            .leftJoin(manageArticle.schedules, manageSchedule)
+            .where(
+                manageSchedule.year.eq(year),
+                manageArticle.office.id.eq(userOfficeId),
+                manageArticle.deletedAt.isNull()
+            )
+            .offset(pageRequest.getOffset())
+            .limit(pageRequest.getPageSize());
+
+        return sortAndFetchtoPage(pageRequest, manageArticle, query);
+    }
+
+    @Override
+    public Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYearAndProgress(
+        Long userOfficeId, Integer year, Pageable pageRequest, List<Progress> progresses
+    ) {
+        QManageArticle manageArticle = QManageArticle.manageArticle;
+        QManageSchedule manageSchedule = QManageSchedule.manageSchedule;
+
+        JPAQuery<ManageArticle> query = queryFactory.selectFrom(manageArticle)
+            .leftJoin(manageArticle.schedules, manageSchedule)
+            .where(
+                manageSchedule.year.eq(year),
+                manageArticle.office.id.eq(userOfficeId),
+                manageArticle.deletedAt.isNull(),
+                manageArticle.progress.in(progresses)
+            )
+            .offset(pageRequest.getOffset())
+            .limit(pageRequest.getPageSize());
+
+        return sortAndFetchtoPage(pageRequest, manageArticle, query);
+    }
+
+    @NotNull
+    private Page<ManageArticle> sortAndFetchtoPage(
+        Pageable pageRequest, QManageArticle manageArticle, JPAQuery<ManageArticle> query
+    ) {
         for (Sort.Order order : pageRequest.getSort()) {
             query.orderBy(
                 new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC,

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.final_10aeat.domain.manageArticle.repository;
 
 import com.final_10aeat.common.enumclass.Progress;
+import com.final_10aeat.domain.manageArticle.dto.request.GetMonthlyListWithYearQuery;
+import com.final_10aeat.domain.manageArticle.dto.request.GetYearListQuery;
 import com.final_10aeat.domain.manageArticle.entity.ManageArticle;
 import com.final_10aeat.domain.manageArticle.entity.QManageArticle;
 import com.final_10aeat.domain.manageArticle.entity.QManageSchedule;
@@ -42,26 +44,7 @@ public class ManageArticleQueryDslRepositoryImpl implements ManageArticleQueryDs
             .offset(pageRequest.getOffset())
             .limit(pageRequest.getPageSize());
 
-        return sortAndFetchtoPage(pageRequest, manageArticle, query);
-    }
-
-    @Override
-    public Page<ManageArticle> findAllByUnDeletedOfficeIdAndScheduleYear(Long userOfficeId,
-        Integer year, Pageable pageRequest) {
-        QManageArticle manageArticle = QManageArticle.manageArticle;
-        QManageSchedule manageSchedule = QManageSchedule.manageSchedule;
-
-        JPAQuery<ManageArticle> query = queryFactory.selectFrom(manageArticle)
-            .leftJoin(manageArticle.schedules, manageSchedule)
-            .where(
-                manageSchedule.year.eq(year),
-                manageArticle.office.id.eq(userOfficeId),
-                manageArticle.deletedAt.isNull()
-            )
-            .offset(pageRequest.getOffset())
-            .limit(pageRequest.getPageSize());
-
-        return sortAndFetchtoPage(pageRequest, manageArticle, query);
+        return sortAndFetchToPage(pageRequest, manageArticle, query);
     }
 
     @Override
@@ -82,11 +65,50 @@ public class ManageArticleQueryDslRepositoryImpl implements ManageArticleQueryDs
             .offset(pageRequest.getOffset())
             .limit(pageRequest.getPageSize());
 
-        return sortAndFetchtoPage(pageRequest, manageArticle, query);
+        return sortAndFetchToPage(pageRequest, manageArticle, query);
+    }
+
+    @Override
+    public Page<ManageArticle> findAllByYear(GetYearListQuery command) {
+        QManageArticle manageArticle = QManageArticle.manageArticle;
+        QManageSchedule manageSchedule = QManageSchedule.manageSchedule;
+        Pageable pageRequest = command.pageRequest();
+
+        JPAQuery<ManageArticle> query = queryFactory.selectFrom(manageArticle)
+            .leftJoin(manageArticle.schedules, manageSchedule)
+            .where(
+                manageSchedule.year.eq(command.year()),
+                manageArticle.office.id.eq(command.officeId()),
+                manageArticle.deletedAt.isNull()
+            )
+            .offset(pageRequest.getOffset())
+            .limit(pageRequest.getPageSize());
+
+        return sortAndFetchToPage(pageRequest, manageArticle, query);
+    }
+
+    @Override
+    public Page<ManageArticle> findAllByYearAndMonthly(GetMonthlyListWithYearQuery command) {
+        QManageArticle manageArticle = QManageArticle.manageArticle;
+        QManageSchedule manageSchedule = QManageSchedule.manageSchedule;
+        Pageable pageRequest = command.pageRequest();
+
+        JPAQuery<ManageArticle> query = queryFactory.selectFrom(manageArticle)
+            .leftJoin(manageArticle.schedules, manageSchedule)
+            .where(
+                manageSchedule.year.eq(command.year()),
+                manageSchedule.month.eq(command.month()),
+                manageArticle.office.id.eq(command.officeId()),
+                manageArticle.deletedAt.isNull()
+            )
+            .offset(pageRequest.getOffset())
+            .limit(pageRequest.getPageSize());
+
+        return sortAndFetchToPage(pageRequest, manageArticle, query);
     }
 
     @NotNull
-    private Page<ManageArticle> sortAndFetchtoPage(
+    private Page<ManageArticle> sortAndFetchToPage(
         Pageable pageRequest, QManageArticle manageArticle, JPAQuery<ManageArticle> query
     ) {
         for (Sort.Order order : pageRequest.getSort()) {

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleRepository.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleRepository.java
@@ -14,9 +14,5 @@ public interface ManageArticleRepository extends JpaRepository<ManageArticle, Lo
 
     List<ManageArticle> findAllByOfficeIdAndDeletedAtNull(Long id);
 
-    List<ManageArticle> findAllByOfficeIdAndDeletedAtNullAndProgressIn(
-        Long office_id, List<Progress> progress
-    );
-
     Optional<ManageArticle> findByIdAndDeletedAtNull(Long id);
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
@@ -1,11 +1,13 @@
 package com.final_10aeat.domain.manageArticle.service;
 
+import static com.final_10aeat.domain.manageArticle.dto.request.GetYearListQuery.toQueryDto;
 import static java.util.Optional.ofNullable;
 
 import com.final_10aeat.common.enumclass.Progress;
 import com.final_10aeat.common.exception.ArticleNotFoundException;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.articleIssue.entity.ArticleIssue;
+import com.final_10aeat.domain.manageArticle.dto.request.GetMonthlyListWithYearQuery;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ManageArticleSummaryResponse;
@@ -104,10 +106,9 @@ public class ReadManageArticleService {
     public Page<ListManageArticleResponse> listArticleByProgress(
         Integer year, Long userOfficeId, Pageable pageRequest
     ) {
-        Page<ManageArticle> articles = manageArticleRepository
-            .findAllByUnDeletedOfficeIdAndScheduleYear(userOfficeId, year, pageRequest);
-
-        return articles.map(this::listArticleFrom);
+        return manageArticleRepository
+            .findAllByYear(toQueryDto(year, userOfficeId, pageRequest))
+            .map(this::listArticleFrom);
     }
 
     public Page<ListManageArticleResponse> listArticleByProgress(
@@ -164,45 +165,20 @@ public class ReadManageArticleService {
         return monthly;
     }
 
-    public List<ListManageArticleResponse> monthlyListArticle(
-        Long userOfficeId, Integer year, Integer month
+    public Page<ListManageArticleResponse> monthlyListArticle(
+        Long userOfficeId, Integer year, Integer month, Pageable pageRequest
     ) {
-        List<ManageArticle> articles = manageArticleRepository
-            .findAllByOfficeIdAndDeletedAtNull(userOfficeId);
-
         if (ofNullable(month).isEmpty()) {
-            return listArticleMonthlyNullFrom(articles, year);
+            return manageArticleRepository
+                .findAllByYear(toQueryDto(year, userOfficeId, pageRequest))
+                .map(this::listArticleFrom);
         }
 
-        return listArticleMonthlyFrom(articles, year, month);
-    }
-
-    private List<ListManageArticleResponse> listArticleMonthlyFrom(
-        List<ManageArticle> articles,
-        Integer year, Integer month
-    ) {
-        return articles.stream()
-            .filter(
-                article -> article.getSchedules().stream()
-                    .anyMatch(schedule ->
-                        schedule.getYear().equals(year) && schedule.getMonth().equals(month)
-                    )
+        return manageArticleRepository
+            .findAllByYearAndMonthly(GetMonthlyListWithYearQuery
+                .toQueryDto(year, month, userOfficeId, pageRequest)
             )
-            .map(this::listArticleFrom)
-            .toList();
-    }
-
-    private List<ListManageArticleResponse> listArticleMonthlyNullFrom(
-        List<ManageArticle> articles,
-        Integer year
-    ) {
-        return articles.stream()
-            .filter(
-                article -> article.getSchedules().stream()
-                    .anyMatch(schedule -> schedule.getYear().equals(year))
-            )
-            .map(this::listArticleFrom)
-            .toList();
+            .map(this::listArticleFrom);
     }
 
     public Page<ListManageArticleResponse> search(

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
@@ -101,36 +101,24 @@ public class ReadManageArticleService {
             .build();
     }
 
-    public List<ListManageArticleResponse> listArticle(
-        Integer year, Long userOfficeId, Boolean complete
+    public Page<ListManageArticleResponse> listArticleByProgress(
+        Integer year, Long userOfficeId, Pageable pageRequest
     ) {
-        if (ofNullable(complete).isEmpty()) {
-            List<ManageArticle> articles = manageArticleRepository
-                .findAllByOfficeIdAndDeletedAtNull(userOfficeId);
+        Page<ManageArticle> articles = manageArticleRepository
+            .findAllByUnDeletedOfficeIdAndScheduleYear(userOfficeId, year, pageRequest);
 
-            return articles.stream()
-                .filter(
-                    article -> article.getSchedules().stream()
-                        .anyMatch(
-                            schedule -> schedule.getYear().equals(year)
-                        )
-                )
-                .map(this::listArticleFrom).toList();
-        } else {
-            List<ManageArticle> articles = manageArticleRepository
-                .findAllByOfficeIdAndDeletedAtNullAndProgressIn(
-                    userOfficeId, complete ? completeProgress : unCompleteProgress
-                );
+        return articles.map(this::listArticleFrom);
+    }
 
-            return articles.stream()
-                .filter(
-                    article -> article.getSchedules().stream()
-                        .anyMatch(
-                            schedule -> schedule.getYear().equals(year)
-                        )
-                )
-                .map(this::listArticleFrom).toList();
-        }
+    public Page<ListManageArticleResponse> listArticleByProgress(
+        Integer year, Long userOfficeId, Pageable pageRequest, Boolean complete
+    ) {
+        Page<ManageArticle> articles = manageArticleRepository
+            .findAllByUnDeletedOfficeIdAndScheduleYearAndProgress(
+                userOfficeId, year, pageRequest, complete ? completeProgress : unCompleteProgress
+            );
+
+        return articles.map(this::listArticleFrom);
     }
 
     private ListManageArticleResponse listArticleFrom(ManageArticle article) {

--- a/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
@@ -2,6 +2,7 @@ package com.final_10aeat.domain.manageArticle.unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -30,6 +31,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 public class ReadManageArticleServiceTest {
 
@@ -152,7 +157,7 @@ public class ReadManageArticleServiceTest {
     }
 
     @Test
-    @DisplayName("listArticle() 에 성공한다")
+    @DisplayName("listArticleByProgress()withOut complete 에 성공한다")
     void listArticle_WillSuccess() {
         // given
         article1.addSchedule(schedule1);
@@ -160,19 +165,21 @@ public class ReadManageArticleServiceTest {
         article1.addSchedule(schedule4);
         article2.addSchedule(schedule2);
 
-        List<ManageArticle> articleList = List.of(article1, article2);
+        Page<ManageArticle> articleList = new PageImpl<>(
+            List.of(article1, article2)
+        );
 
-        given(manageArticleRepository.findAllByOfficeIdAndDeletedAtNull(anyLong()))
+        given(manageArticleRepository.findAllByYear(any()))
             .willReturn(articleList);
 
         // when
-        List<ListManageArticleResponse> result =
-            readManageArticleService.listArticle(2024, 1L, null);
+        Page<ListManageArticleResponse> result =
+            readManageArticleService.listArticleByProgress(
+                2024, 1L, PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "id"))
+            );
 
         // then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).allSchedule()).isEqualTo(3);
-        assertThat(result.get(0).completedSchedule()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(2);
     }
 
     @Test
@@ -206,16 +213,16 @@ public class ReadManageArticleServiceTest {
         article1.addSchedule(schedule4);
         article2.addSchedule(schedule2);
 
-        List<ManageArticle> articleList = List.of(article1, article2);
+        Page<ManageArticle> articleList = new PageImpl<>(List.of(article1, article2));
 
-        given(manageArticleRepository.findAllByOfficeIdAndDeletedAtNull(anyLong()))
+        given(manageArticleRepository.findAllByYearAndMonthly(any()))
             .willReturn(articleList);
 
         // when
         var result =
-            readManageArticleService.monthlyListArticle(1L, 2024, 1);
+            readManageArticleService.monthlyListArticle(1L, 2024, 1, null);
 
         // then
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.getSize()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
# Pull Request 요약

- 법정점검에서 List를 반환하는 메소드들을 Page로 반환하도록 변경했습니다
- QueryDSL을 사용하여 리팩토링 했습니다

## 변경 사항

- ReadManageArticleController : 목록 조회시 List를 반환하는 코드 Page로 변경
- Repository에 Dto를 사용하여 값을 전달하도록 변경
  - GetMonthlyListWithYearQuery
  - GetYearListQuery
- ManageArticleQueryDslRepository : 추상 메소드 추가
- ManageArticleQueryDslRepositoryImpl : 
  - sortAndFetchToPage : 검색, Page 변환 메소드 추출
  - 조회 메소드 추가
- ManageArticleRepository : 사용하지 않는 메소드 삭제
- ReadManageArticleService : List 조회 메소드 Page로 변환
- ReadManageArticleControllerDocsTest : 문서 최신화
- ReadManageArticleServiceTest : 코드에 맞게 테스트 변경

## 관련 이슈

- #172 

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [x] 테스트 코드 작성
- [x] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-06-10)
- 작업 종료일: (2024-06-11)
