### PR TITLE
[Fix] RepairArticle 조회 쿼리를 이슈가 있는 게시물과 없는 게시물을 정확히 구분하여 페이징 처리

### DIFF
--- a/src/main/java/com/final_10aeat/domain/repairArticle/repository/CustomProgressRepository.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/repository/CustomProgressRepository.java
@@ -2,7 +2,9 @@ package com.final_10aeat.domain.repairArticle.repository;
 
 import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface CustomProgressRepository extends JpaRepository<CustomProgress, Long> {
 
+    List<CustomProgress> findAllByOrderByStartScheduleAsc();
 }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleQueryDslRepository.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/repository/RepairArticleQueryDslRepository.java
@@ -18,7 +18,7 @@ public interface RepairArticleQueryDslRepository {
     List<RepairArticle> findSoftDeletedBefore(LocalDateTime cutoffDate);
 
     Page<RepairArticle> findByOfficeIdAndProgressInAndCategoryOrderByIdDesc(
-        Long officeId, List<Progress> progresses, ArticleCategory category, Pageable pageable);
+        Long officeId, List<Progress> progresses, ArticleCategory category, Pageable pageable,List<Long> checkedIssueIds);
 
     List<RepairArticle> findByOfficeIdAndProgressIn(Long officeId, List<Progress> progresses);
 

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/GetRepairArticleService.java
@@ -12,6 +12,7 @@ import com.final_10aeat.domain.repairArticle.entity.CustomProgress;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticle;
 import com.final_10aeat.domain.repairArticle.entity.RepairArticleImage;
 import com.final_10aeat.domain.repairArticle.repository.ArticleViewRepository;
+import com.final_10aeat.domain.repairArticle.repository.CustomProgressRepository;
 import com.final_10aeat.domain.repairArticle.repository.RepairArticleRepository;
 import com.final_10aeat.domain.save.repository.ArticleSaveRepository;
 import java.util.List;
@@ -30,6 +31,7 @@ public class GetRepairArticleService {
     private final ArticleSaveRepository articleSaveRepository;
     private final ArticleIssueCheckRepository articleIssueCheckRepository;
     private final ArticleViewRepository articleViewRepository;
+    private final CustomProgressRepository customProgressRepository;
 
     public RepairArticleSummaryDto getRepairArticleSummary(Long officeId,
         UserIdAndRole userIdAndRole) {
@@ -115,10 +117,11 @@ public class GetRepairArticleService {
     }
 
     public List<CustomProgressResponseDto> getCustomProgressList(Long articleId) {
-        RepairArticle article = repairArticleRepository.findById(articleId)
+        repairArticleRepository.findById(articleId)
             .orElseThrow(ArticleNotFoundException::new);
 
-        return article.getCustomProgressSet().stream()
+        return customProgressRepository.findAllByOrderByStartScheduleAsc().stream()
+            .filter(customProgress -> customProgress.getRepairArticle().getId().equals(articleId))
             .map(this::mapToCustomProgressDto)
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
+++ b/src/main/java/com/final_10aeat/domain/repairArticle/service/ManagerArticleListService.java
@@ -26,7 +26,7 @@ public class ManagerArticleListService {
     public Page<ManagerRepairArticleResponseDto> getAllRepairArticles(Long officeId,
         List<Progress> progresses, ArticleCategory category, Pageable pageable) {
         Page<RepairArticle> articles = repairArticleRepository.findByOfficeIdAndProgressInAndCategoryOrderByIdDesc(
-            officeId, progresses, category, pageable);
+            officeId, progresses, category, pageable,List.of());
 
         return articles.map(this::mapToDto);
     }


### PR DESCRIPTION
# ⭐️ [Fix] RepairArticle 조회 쿼리를 이슈가 있는 게시물과 없는 게시물을 정확히 구분하여 페이징 처리

## 🛠️ 변경 사항 :
 - enabled=true인 이슈가 있는 게시물과 없는 게시물을 정확히 구분하여 중복 조회 방지
 - 이슈가 없는 게시물에 대한 쿼리를 `repairArticle.issues.isEmpty().or(repairArticle.issues.any().enabled.isFalse())`로 수정
 - 이슈가 있는 게시물과 없는 게시물을 각각 조회하여 결합한 후 페이지네이션 적용
 - 전체 게시물 수를 계산하는 쿼리를 추가하여 정확한 페이지네이션 처리


## 💡 관련 이슈

- #186 

## 📃 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트


## ⏱️ 작업 기간

- 작업 시작일: (2024-06-12)
- 작업 종료일: (2024-06-12)

