### PR TITLE
[Fix] 목록 조회시 가까운 일정이 상단에 위치하도록 검색한다

### DIFF
--- a/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/SearchManageArticleQuery.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/dto/request/SearchManageArticleQuery.java
@@ -1,8 +1,10 @@
 package com.final_10aeat.domain.manageArticle.dto.request;
 
 import java.time.LocalDateTime;
+import lombok.Builder;
 import org.springframework.data.domain.Pageable;
 
+@Builder
 public record SearchManageArticleQuery(
     LocalDateTime now,
     String keyword,
@@ -12,17 +14,4 @@ public record SearchManageArticleQuery(
     Pageable pageRequest
 ) {
 
-    public static SearchManageArticleQuery toSearchQuery(
-        LocalDateTime now, String keyword, Integer year,
-        Integer month, Long officeId, Pageable pageRequest
-    ) {
-        return new SearchManageArticleQuery(
-            now,
-            keyword,
-            year,
-            month,
-            officeId,
-            pageRequest
-        );
-    }
 }

--- a/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/repository/ManageArticleQueryDslRepositoryImpl.java
@@ -165,7 +165,6 @@ public class ManageArticleQueryDslRepositoryImpl implements ManageArticleQueryDs
         BooleanBuilder booleanBuilder = new BooleanBuilder();
 
         booleanBuilder.and(manageArticle.office.id.eq(command.officeId()));
-        booleanBuilder.and(manageSchedule.year.eq(command.year()));
         booleanBuilder.and(manageArticle.deletedAt.isNull());
 
         if (ofNullable(command.keyword()).isPresent()) {
@@ -173,6 +172,12 @@ public class ManageArticleQueryDslRepositoryImpl implements ManageArticleQueryDs
                 .or(manageArticle.legalBasis.contains(command.keyword()))
                 .or(manageArticle.target.contains(command.keyword()))
                 .or(manageArticle.responsibility.contains(command.keyword()))
+            );
+        }
+
+        if (ofNullable(command.year()).isPresent()) {
+            booleanBuilder.and(
+                manageSchedule.year.eq(command.year())
             );
         }
 

--- a/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
+++ b/src/main/java/com/final_10aeat/domain/manageArticle/service/ReadManageArticleService.java
@@ -1,7 +1,6 @@
 package com.final_10aeat.domain.manageArticle.service;
 
 import static com.final_10aeat.domain.manageArticle.dto.request.GetYearListPageQuery.toQueryDto;
-import static com.final_10aeat.domain.manageArticle.dto.request.SearchManageArticleQuery.toSearchQuery;
 import static java.util.Optional.ofNullable;
 
 import com.final_10aeat.common.enumclass.Progress;
@@ -10,6 +9,7 @@ import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.domain.articleIssue.entity.ArticleIssue;
 import com.final_10aeat.domain.manageArticle.dto.request.GetMonthlyListWithYearQuery;
 import com.final_10aeat.domain.manageArticle.dto.request.GetYearListQuery;
+import com.final_10aeat.domain.manageArticle.dto.request.SearchManageArticleQuery;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ManageArticleSummaryResponse;
@@ -113,7 +113,11 @@ public class ReadManageArticleService {
         Integer year, Long userOfficeId, Pageable pageRequest
     ) {
         return manageArticleRepository
-            .findAllByYear(toQueryDto(year, userOfficeId, pageRequest))
+            .searchByKeyword(SearchManageArticleQuery.builder()
+                .year(year)
+                .officeId(userOfficeId)
+                .pageRequest(pageRequest)
+                .build())
             .map(this::listArticleFrom);
     }
 
@@ -198,7 +202,14 @@ public class ReadManageArticleService {
         Long userOfficeId, Integer year, String keyword, Integer month, Pageable pageRequest,
         LocalDateTime now) {
         return manageArticleRepository.searchByKeyword(
-                toSearchQuery(now, keyword, year, month, userOfficeId, pageRequest)
+                SearchManageArticleQuery.builder()
+                    .now(now)
+                    .keyword(keyword)
+                    .year(year)
+                    .month(month)
+                    .officeId(userOfficeId)
+                    .pageRequest(pageRequest)
+                    .build()
             )
             .map(this::searchArticleFrom);
     }

--- a/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
+++ b/src/test/java/com/final_10aeat/domain/manageArticle/unit/ReadManageArticleServiceTest.java
@@ -12,8 +12,8 @@ import com.final_10aeat.common.exception.ArticleNotFoundException;
 import com.final_10aeat.common.exception.UnauthorizedAccessException;
 import com.final_10aeat.common.util.EntityUtil;
 import com.final_10aeat.domain.articleIssue.entity.ArticleIssue;
-import com.final_10aeat.domain.manageArticle.dto.request.GetYearListPageQuery;
 import com.final_10aeat.domain.manageArticle.dto.request.GetYearListQuery;
+import com.final_10aeat.domain.manageArticle.dto.request.SearchManageArticleQuery;
 import com.final_10aeat.domain.manageArticle.dto.response.DetailManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.ListManageArticleResponse;
 import com.final_10aeat.domain.manageArticle.dto.response.SummaryManageArticleResponse;
@@ -171,7 +171,7 @@ public class ReadManageArticleServiceTest {
             List.of(article1, article2)
         );
 
-        given(manageArticleRepository.findAllByYear(any(GetYearListPageQuery.class)))
+        given(manageArticleRepository.searchByKeyword(any(SearchManageArticleQuery.class)))
             .willReturn(articleList);
 
         // when


### PR DESCRIPTION
# Pull Request 요약

- 목록 조회시 가까운 일정이 상단에 위치하도록 검색한다

## 변경 사항

- SearchManageArticleQuery : 메소드 생성을 Builder로 변경
- managearticlequerydslrepositoryimpl : 동적으로 올 수 있는 쿼리에 대해 변경
- ReadManageArticleService : 목록 조회시 사용하는 메소드 변경
- ReadManageArticleServiceTest : 테스트 코드 변경된 로직에 맞게 변경

## 관련 이슈

- #172 

## 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-06-13)
- 작업 종료일: (2024-06-13)